### PR TITLE
Support for syncing data to Community Lands.

### DIFF
--- a/controllers/community-lands.js
+++ b/controllers/community-lands.js
@@ -1,0 +1,108 @@
+require('dotenv').load()
+
+var archiver = require('archiver');
+var moment = require('moment');
+var fs = require('fs');
+var http = require('http');
+
+function lastSubmission(req, res, next) {
+  var cl_server = process.env.community_lands_server // || default_server
+  var cl_token = process.env.community_lands_token
+
+  if (cl_server == null || cl_token == null)
+    res.json({error: 500, message: 'Please configure community lands server and/or token in settings.'});
+  else {
+    getLastSubmissionDate(function(date) {
+      res.json({date: date});
+    });
+  }
+}
+
+function uploadSubmissions(req, res, next) {
+  var cl_server = process.env.community_lands_server // || default_server
+  var cl_token = process.env.community_lands_token
+
+  if (cl_server == null || cl_token == null)
+    res.json({error: 500, message: 'Please configure community lands server and/or token in settings.'});
+  else {
+    getLastSubmissionDate(function(date) {
+      uploadSubmissionsSince(req, res, next, date);
+    });
+  }
+}
+
+function uploadAllSubmissions(req, res, next) {
+  uploadSubmissionsSince(req, res, next, null);
+}
+
+function uploadSubmissionsSince(req, res, next, since) {
+  var dir = process.env.directory + "/Monitoring/" + process.env.station + "/Submissions";
+
+  var opts = { expand: true, src: ['**/*'], dest: '/Submissions', cwd: dir }
+  if (since != null) {
+    opts['filter'] = function(path) {
+      var stats = fs.statSync(path);
+      if (stats.isFile())
+        return stats.mtime >= since
+      else
+        return true;
+    }
+  }
+
+  var clCallback = function(clRes) {
+    var clData = '';
+    clRes.on('data', function(d) {
+      clData += d;
+    });
+    clRes.on('end', function() {
+      if (res.statusCode >= 200 && res.statusCode <= 299)
+        res.json(JSON.parse(clData));
+      else
+        res.json(JSON.parse({error: true, code: res.statusCode}))
+    });
+  };
+  var clReq = http.request(getCLRequestOpts('POST', '/submissions'), clCallback);
+
+  var archive = archiver.create('zip', {});
+
+  archive.pipe(clReq);
+  archive.bulk(opts);
+  archive.finalize();
+}
+
+function getLastSubmissionDate(callback) {
+  http.request(getCLRequestOpts('GET', '/status'), function(statusRes) {
+    var jsonStr = '';
+    statusRes.on('data', function(d) {
+      jsonStr += d;
+    });
+    statusRes.on('end', function() {
+      if (statusRes.statusCode == 200) {
+        var json = JSON.parse(jsonStr);
+        if (json.error == false && json.entity.found)
+          callback(moment(json.entity.last_modified));
+        else
+          callback(null);
+      }
+    });
+  }).end();
+}
+
+function getCLRequestOpts(method, path) {
+  var opts = {
+    host: process.env.community_lands_server,
+    path: '/api/v1/' + process.env.community_lands_token + path,
+    method: method
+  }
+  if (process.env.community_lands_port != undefined)
+    opts['port'] = process.env.community_lands_port
+  return opts;
+}
+
+module.exports = {
+
+  backup: uploadSubmissions,
+  resync: uploadAllSubmissions,
+  lastBackup: lastSubmission
+
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com/rfc2616/community-lands-monitoring-station/issues"
   },
   "dependencies": {
+    "archiver": "*",
     "body-parser": "^1.13.3",
     "dotenv": "^0.5.1",
     "express": "^4.13.3",

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ var AppendGeoJSON = require ('./middlewares/append-geojson')
 var storage = require('./helpers/community-storage')
 var forms = require('./controllers/forms')
 var error = require('./controllers/error-handler')
+var CommunityLands = require('./controllers/community-lands');
 
 // Configure the Digest strategy for use by Passport.
 //
@@ -89,6 +90,10 @@ app.get('/formList', forms.index)
 
 app.get('/forms', forms.index)
 app.get('/forms/:id', forms.show)
+
+app.get('/backup/latest', CommunityLands.backup);
+app.get('/backup/all', CommunityLands.resync);
+app.get('/backup/status', CommunityLands.lastBackup);
 
 app.head('/submission',
   passport.authenticate('digest', { session: false }),


### PR DESCRIPTION
Submission data can now be uploaded to a Community Lands
server.  In order to enable this, the following variables
must be provided in .env (or equivalent):
- community_lands_token - authentication token from CL website
- community_lands_server - the host name of CL (will be optional)
- community_lands_port - host port (optional)

Currently, the first two are required.

The workflow as of this commit is as follows:
- A request is made to the CL server to get the timestamp for the
  last time a sync was done
- Files are gathered, filtered based on said timestamp
- Files are sent over to the server for sync.

Also exposed is a means of re-syncing all files, ignoring the
timestamp.
