### PR TITLE
Support sending map filters to Community Lands.

### DIFF
--- a/controllers/backup.js
+++ b/controllers/backup.js
@@ -1,0 +1,66 @@
+require('dotenv').load()
+
+var archiver = require('archiver');
+var moment = require('moment');
+var fs = require('fs');
+var http = require('http');
+
+var PREFIX = process.env.data_directory
+var ROOT_PATH = PREFIX + '/Monitoring'
+var BACKUP_FOLDER = ROOT_PATH + '/' + process.env.station + '/Backup'
+var HISTORY_FILE = BACKUP_FOLDER + '/.backup_history.json';
+
+function prepare(req, res, next, cont) {
+  fs.mkdir(BACKUP_FOLDER, function(err) {
+    cont(req, res, next);
+  });
+}
+
+function lastBackup(req, res, next) {
+  prepare(req, res, next, function() {
+    fs.access(HISTORY_FILE, fs.F_OK | fs.R_OK | fs.W_OK, function(err) {
+      if (err) {
+        if (err.code == 'ENOENT')
+          res.json({date: null});
+        else
+          res.json({error: 500, e: err, message: 'Failed to read disk properly for backup.'});
+      } else {
+        fs.readFile(HISTORY_FILE, 'utf8', function(err, data) {
+          res.json(JSON.parse(data));
+        });
+      }
+    });
+  });
+}
+
+function runBackup(req, res, next) {
+  prepare(req, res, next, function() {
+    var date = new Date();
+    var file = process.env.station + "_backup_" + moment(date).format("YYYYMMDDHHmm") + ".zip"
+
+    var dir = process.env.data_directory + "/Monitoring/" + process.env.station + "/Submissions";
+    var opts = { expand: true, src: ['**/*'], dest: '/Submissions', cwd: dir }
+
+    var output = fs.createWriteStream(BACKUP_FOLDER + '/' + file);
+    output.on('close', function() {
+      fs.writeFile(HISTORY_FILE, JSON.stringify({date: date}), 'utf8', function() {
+        res.json({message: 'Data saved successfully', file: file, location: BACKUP_FOLDER + '/' + file});
+      });
+    });
+    output.on('error', function(err) {
+      res.json({error: 500, message: 'Failed to write backup'});
+    });
+
+    var archive = archiver.create('zip', {});
+    archive.pipe(output);
+    archive.bulk(opts);
+    archive.finalize();
+  });
+}
+
+module.exports = {
+
+  backup: runBackup,
+  lastBackup: lastBackup
+
+}

--- a/controllers/community-lands.js
+++ b/controllers/community-lands.js
@@ -49,7 +49,7 @@ function uploadAllSubmissions(req, res, next) {
 }
 
 function uploadSubmissionsSince(req, res, next, since) {
-  var dir = process.env.directory + "/Monitoring/" + process.env.station + "/Submissions";
+  var dir = process.env.data_directory + "/Monitoring/" + process.env.station + "/Submissions";
 
   var opts = { expand: true, src: ['**/*'], dest: '/Submissions', cwd: dir }
   if (since != null) {

--- a/controllers/community-lands.js
+++ b/controllers/community-lands.js
@@ -63,7 +63,9 @@ function uploadSubmissionsSince(req, res, next, since) {
   }
 
   var clReq = http.request(getCLRequestOpts('POST', '/submissions'), clCallback(res));
-
+  clReq.on('error', function(e) {
+    res.json({error: true, code: 1001, message: "Could not make connection to Community Lands"});
+  });
   var archive = archiver.create('zip', {});
 
   archive.pipe(clReq);
@@ -81,7 +83,7 @@ function clCallback(res) {
       if (res.statusCode >= 200 && res.statusCode <= 299)
         res.json(JSON.parse(clData));
       else
-        res.json(JSON.parse({error: true, code: res.statusCode}));
+        res.json({error: true, code: res.statusCode});
     });
   };
 }
@@ -101,6 +103,8 @@ function getLastSubmissionDate(callback) {
           callback(null);
       }
     });
+  }).on('error', function(e) {
+    callback(null);
   }).end();
 }
 

--- a/helpers/autoconfig.js
+++ b/helpers/autoconfig.js
@@ -1,3 +1,7 @@
+// Required for Electron to find initial config
+process.env.directory = process.env.directory || '.'
+process.chdir(process.env.directory)
+
 require('dotenv').load();
 
 // Detect IP, set up defaults for configuration variables if not set
@@ -10,10 +14,9 @@ console.log("----------------------")
 process.env.port = process.env.port || '3000'
 console.log("Port number to use for the local web server")
 console.log("  port: " + process.env.port)
-process.env.directory = process.env.directory || '.'
-process.chdir(process.env.directory)
+process.env.data_directory = process.env.data_directory || process.env.directory
 console.log("Where your Monitoring folder lives")
-console.log("  directory: " + process.env.directory)
+console.log("  directory: " + process.env.data_directory)
 process.env.station = process.env.station || 'DEMO'
 console.log("Name of this monitoring station")
 console.log("(and its station-specific folder under Monitoring)")

--- a/helpers/community-storage.js
+++ b/helpers/community-storage.js
@@ -4,7 +4,7 @@ var fs = require('fs')
 var path = require('path')
 var mkdirp = require('mkdirp')
 
-var PREFIX = process.env.directory;
+var PREFIX = process.env.data_directory;
 var ROOT_PATH = PREFIX + '/Monitoring';
 var GLOBAL_FORMS = ROOT_PATH + '/Forms';
 var GLOBAL_MAPS = ROOT_PATH + '/Maps';

--- a/index.html
+++ b/index.html
@@ -5,13 +5,68 @@
     <link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
     <script>
     var ipc = require('ipc');
+    var updateOnlineStatus = function() {
+      ipc.send('community_lands_online', navigator.onLine);
+    };
+    ipc.on('has_community_lands_online', function(status) {
+      if (status == true || status == 'true')
+        ipc.send('community_lands_status');
+      else {
+        document.getElementById('connection_status').innerHTML = "Offline";
+        document.getElementById('community_lands_sync_date').innerHTML = "Unavailable";
+      }
+    });
+    ipc.on('has_community_lands_status', function(result) {
+      document.getElementById('connection_status').innerHTML = "Online";
+      if (result != null && result != "") {
+        var json = JSON.parse(result);
+        if (json.date)
+          document.getElementById('community_lands_sync_date').innerHTML = new Date(json.date);
+        else
+          document.getElementById('community_lands_sync_date').innerHTML = "Unavailable";
+      } else
+        document.getElementById('community_lands_sync_date').innerHTML = "Unavailable";
+    });
+    ipc.on('has_community_lands_backup', function(result) {
+      var json = JSON.parse(result);
+      var html = "";
+      html += "Upload ";
+      if (json.error) {
+        html += "Failed.";
+        if (json.message)
+          html += " " + json.message;
+      }
+      else {
+        html += "Succeeded. ";
+        html += "Files Uploaded: ";
+        html += json.entity.files_uploaded;
+      }
+      document.getElementById('community_lands_sync_status').innerHTML = html;
+      ipc.send('community_lands_status');
+    });
     ipc.on('has_configuration', function(configuration) {
       document.getElementById('baseUrl').innerHTML = configuration.baseUrl
       document.getElementById('shared_secret').innerHTML = configuration.shared_secret
       document.getElementById('mapUrl').innerHTML = configuration.baseUrl + "/mapfilter"
       document.getElementById('form_folder').innerHTML = configuration.directory + "/Monitoring/" + configuration.station + "/Forms"
+      if (configuration.community_lands == true)
+        document.getElementById('community_lands_content').className = "";
     });
     ipc.send('show_configuration');
+
+    window.addEventListener('online',  updateOnlineStatus);
+    window.addEventListener('offline',  updateOnlineStatus);
+
+    updateOnlineStatus();
+
+    function communityLandsUpload() {
+      if (navigator.onLine) {
+        document.getElementById('community_lands_sync_status').innerHTML = "Uploading, please wait...";
+        ipc.send('community_lands_backup');
+      } else {
+        alert("No internet connection detected");
+      }
+    }
     </script>
   </head>
   <body><div class="container-fluid"><div class="row"><div class="col-xs-12">
@@ -30,7 +85,7 @@
       </div>
       <div><b id="shared_secret"></b></div>
     </div>
-    <h4>Browser settings</h3>
+    <h4>Browser settings</h4>
     <div class="well">
       <div>
         URL for viewing maps in your browser:
@@ -45,6 +100,20 @@
       <div><b id="form_folder"></b></div>
       <div class="btn btn-small btn-primary" style="margin-top: 10px">Backup Data</div>
     </div>
-
+    <div class="hidden" id="community_lands_content">
+      <h4>Community Lands</h4>
+      <div class="well">
+        <div>
+          <span>Connection Status: </span>
+          <span id="connection_status" style="font-weight: bold">Pending</span>
+        </div>
+        <div>
+          <span>Last Synchronized: </span>
+          <span id="community_lands_sync_date" style="font-weight: bold">Unavailable</span>
+        </div>
+        <div class="btn btn-small btn-primary" style="margin-top: 10px" onclick="javascript:communityLandsUpload()">Upload</div>
+        <div style="margin-top: 10px" id="community_lands_sync_status"></div>
+      </div>
+    </div>
   </div></div></div></body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,10 +4,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
     <script>
-    var ipc = require('ipc');
+    const ipc = require('ipc');
+    const shell = require('shell');
+    var config = null;
     var updateOnlineStatus = function() {
       ipc.send('community_lands_online', navigator.onLine);
     };
+    ipc.on('backup_submissions_complete', function(result) {
+      document.getElementById("backup_status").innerHTML = "";
+      var json = JSON.parse(result);
+      if (json.error) {
+        alert(json.message);
+      } else {
+        document.getElementById('backup_status').innerHTML = 'Backup of ' + json.file + 
+          ' complete.<br/>Open: <a id="backup_file" href="javascript:openBackupFile();" ' + 
+          'data-location="' + json.location + '">' + json.location + '</a>';
+        ipc.send('check_last_backup');
+      }
+    });
+    ipc.on('has_last_backup', function(result) {
+      var json = JSON.parse(result);
+      if (json.date)
+        document.getElementById('last_backup').innerHTML = '<p>Last Backup: <a href="javascript:openBackupFolder();">' + new Date(json.date) + '</a></p>';
+    });
     ipc.on('has_community_lands_online', function(status) {
       if (status == true || status == 'true')
         ipc.send('community_lands_status');
@@ -45,6 +64,7 @@
       ipc.send('community_lands_status');
     });
     ipc.on('has_configuration', function(configuration) {
+      config = configuration;
       document.getElementById('baseUrl').innerHTML = configuration.baseUrl
       document.getElementById('shared_secret').innerHTML = configuration.shared_secret
       document.getElementById('mapUrl').innerHTML = configuration.baseUrl + "/mapfilter"
@@ -53,6 +73,7 @@
         document.getElementById('community_lands_content').className = "";
     });
     ipc.send('show_configuration');
+    ipc.send('check_last_backup');
 
     window.addEventListener('online',  updateOnlineStatus);
     window.addEventListener('offline',  updateOnlineStatus);
@@ -66,6 +87,21 @@
       } else {
         alert("No internet connection detected");
       }
+    }
+
+    function backupFiles() {
+      document.getElementById('backup_status').innerHTML = "Saving files, please wait...";
+      ipc.send('backup_submissions');
+    }
+
+    function openBackupFile() {
+      var file = document.getElementById('backup_file').getAttribute('data-location');
+      shell.showItemInFolder(file);
+    }
+
+    function openBackupFolder() {
+      if (config)
+        shell.openItem(config.directory + "/Monitoring/" + config.station + "/Backup");
     }
     </script>
   </head>
@@ -98,7 +134,9 @@
         Folder for blank monitoring forms:
       </div>
       <div><b id="form_folder"></b></div>
-      <div class="btn btn-small btn-primary" style="margin-top: 10px">Backup Data</div>
+      <div id="last_backup"></div>
+      <div class="btn btn-small btn-primary" style="margin-top: 10px" onclick="javascript:backupFiles()">Backup Data</div>
+      <div style="margin-top: 10px" id="backup_status"></div>
     </div>
     <div class="hidden" id="community_lands_content">
       <h4>Community Lands</h4>

--- a/main.js
+++ b/main.js
@@ -10,13 +10,12 @@ var server = require('./server')
 ipc.on('show_configuration', function(event, arg) {
   try{
     _results = {
-      'directory': process.env.directory,
+      'directory': process.env.data_directory,
       'station': process.env.station,
       'baseUrl': process.env.baseUrl,
-      'shared_secret': process.env.shared_secret
+      'shared_secret': process.env.shared_secret,
+      'community_lands': !(process.env.community_lands_server === undefined || process.env.community_lands_token === undefined)
     };
-    if (process.env.community_lands_server != null && process.env.community_lands_token != null)
-      _results['community_lands'] = true;
     console.log(_results);
     event.sender.send('has_configuration', _results);
   } catch (err) {

--- a/main.js
+++ b/main.js
@@ -23,6 +23,44 @@ ipc.on('show_configuration', function(event, arg) {
   }
 });
 
+ipc.on('backup_submissions', function(event, arg) {
+  var options = {
+    hostname: 'localhost',
+    port: process.env.port || 3000,
+    path: '/save/all',
+    method: 'GET'
+  };
+  var req = http.request(options, function(res) {
+    var data = "";
+    res.on('data', function(chunk) {
+      data += chunk;
+    });
+    res.on('end', function() {
+      event.sender.send('backup_submissions_complete', data);
+    });
+  }).on('error', function(e) {
+    event.sender.send('backup_submissions_complete', '{"error":true, "message":"Could not connect to server"}');
+  }).end();
+});
+
+ipc.on('check_last_backup', function(event, arg) {
+  var options = {
+    hostname: 'localhost',
+    port: process.env.port || 3000,
+    path: '/save/status',
+    method: 'GET'
+  };
+  var req = http.request(options, function(res) {
+    var data = ""
+    res.on('data', function(chunk) {
+      data += chunk;
+    });
+    res.on('end', function() {
+      event.sender.send('has_last_backup', data);
+    });
+  }).end();
+});
+
 ipc.on('community_lands_backup', function(event, arg) {
   if (process.env.community_lands_server) {
     var options = {

--- a/middlewares/append-geojson.js
+++ b/middlewares/append-geojson.js
@@ -2,7 +2,7 @@ require('dotenv').load()
 
 var storage = require('../helpers/community-storage.js')
 
-var PREFIX = process.env.directory;
+var PREFIX = process.env.data_directory;
 var ROOT_PATH = PREFIX + '/Monitoring';
 var SUBMISSIONS = ROOT_PATH + '/' + process.env.station + '/Submissions';
 var MAP = 'Monitoring.geojson';

--- a/middlewares/process-submission.js
+++ b/middlewares/process-submission.js
@@ -8,7 +8,7 @@ var defaults = {
   geojson: true
 }
 
-var PREFIX = process.env.directory
+var PREFIX = process.env.data_directory
 var ROOT_PATH = PREFIX + '/Monitoring'
 var SUBMISSIONS = ROOT_PATH + '/' + process.env.station + '/Submissions'
 

--- a/server.js
+++ b/server.js
@@ -43,7 +43,11 @@ var fs = require('fs');
 
 app.use(morgan('dev'));
 
-app.use('/mapfilter',express.static('mapfilter'));
+app.use('/mapfilter',express.static(__dirname + '/mapfilter'));
+app.get('/mapfilter/json/mapfilter-config.json', function(req, res, next) {
+  res.json({canSaveFilters: true});
+});
+
 app.use('/monitoring-files',express.static('Monitoring'));
 
 app.get('/',
@@ -78,7 +82,6 @@ app.get('/json/Monitoring.json', function(req, res, next) {
   });
 });
 
-
 app.get('/files', function(req, res, next) {
   list.getFormUrls(function(err, files) {
     if (err)
@@ -97,6 +100,8 @@ app.get('/forms/:id', forms.show)
 app.get('/backup/latest', CommunityLands.backup);
 app.get('/backup/all', CommunityLands.resync);
 app.get('/backup/status', CommunityLands.lastBackup);
+
+app.post('/filters', bodyParser.json(), CommunityLands.saveFilter);
 
 app.head('/submission',
   passport.authenticate('digest', { session: false }),

--- a/server.js
+++ b/server.js
@@ -20,6 +20,8 @@ var forms = require('./controllers/forms')
 var error = require('./controllers/error-handler')
 var CommunityLands = require('./controllers/community-lands');
 
+var Backup = require('./controllers/backup');
+
 // Configure the Digest strategy for use by Passport.
 //
 // The Digest strategy requires a `secret`function, which is used to look up
@@ -100,6 +102,9 @@ app.get('/forms/:id', forms.show)
 app.get('/backup/latest', CommunityLands.backup);
 app.get('/backup/all', CommunityLands.resync);
 app.get('/backup/status', CommunityLands.lastBackup);
+
+app.get('/save/all', Backup.backup);
+app.get('/save/status', Backup.lastBackup);
 
 app.post('/filters', bodyParser.json(), CommunityLands.saveFilter);
 


### PR DESCRIPTION
Community Lands can now accept filter information for
MapFilter.  Updated the controller to support accepting
uploads and sending them over to Community Lands.

Also, return a config file to MapFilter that tells it that
it can save filters, which will cause a save button to appear.
