### PR TITLE
Store settings information in data directory.

### DIFF
--- a/controllers/backup.js
+++ b/controllers/backup.js
@@ -1,13 +1,12 @@
-require('dotenv').load()
+var settings = require('../helpers/settings')
 
 var archiver = require('archiver')
 var moment = require('moment')
+var path = require('path')
 var fs = require('fs')
 
-var PREFIX = process.env.data_directory
-var ROOT_PATH = PREFIX + '/Monitoring'
-var BACKUP_FOLDER = ROOT_PATH + '/' + process.env.station + '/Backup'
-var HISTORY_FILE = BACKUP_FOLDER + '/.backup_history.json'
+const BACKUP_FOLDER = settings.getBackupDirectory()
+const HISTORY_FILE = path.join(BACKUP_FOLDER, '.backup_history.json')
 
 function prepare (req, res, next, cont) {
   fs.mkdir(BACKUP_FOLDER, function (err) {
@@ -36,9 +35,9 @@ function lastBackup (req, res, next) {
 function runBackup (req, res, next) {
   prepare(req, res, next, function () {
     var date = new Date()
-    var file = process.env.station + '_backup_' + moment(date).format('YYYYMMDDHHmm') + '.zip'
+    var file = settings.getStation() + '_backup_' + moment(date).format('YYYYMMDDHHmm') + '.zip'
 
-    var dir = process.env.data_directory + '/Monitoring/' + process.env.station + '/Submissions'
+    var dir = settings.getSubmissionsDirectory()
     var opts = { expand: true, src: ['**/*'], dest: '/Submissions', cwd: dir }
 
     var output = fs.createWriteStream(BACKUP_FOLDER + '/' + file)

--- a/controllers/bing-proxy.js
+++ b/controllers/bing-proxy.js
@@ -1,0 +1,64 @@
+var settings = require('../helpers/settings')
+
+var fs = require('fs')
+var path = require('path')
+var request = require('request')
+
+var BING_ROOT = path.join(settings.getGlobalMapsDirectory(), 'Bing')
+
+function prepare(req, res, next) {
+  fs.access(BING_ROOT, fs.F_OK | fs.R_OK | fs.W_OK, function(err) {
+    if (err && err.code == 'ENOENT') {
+      fs.mkdir(BING_ROOT, function(err2) {
+        next(err);
+      });
+    } else
+      next(err);
+  });
+}
+
+function handleProxy(req, res) {
+  var tileUrl = decodeURIComponent(req.param('url'))
+  var fileName = tileUrl.match(/\/([^\/]*.jpe?g)/)[1]
+  var pathName = path.join(BING_ROOT, fileName)
+  try {
+    var stats = fs.statSync(pathName)
+    if (stats.size < 100) {
+      fs.unlinkSync(pathName)
+      throw new Error('Found truncated file')
+    }
+    var stream = fs.createReadStream(pathName)
+    console.log('cached: ' + pathName)
+    stream.pipe(res)
+  } catch (err) {
+    console.log('downloading: ' + fileName)
+    var r = request
+      .get(tileUrl)
+      .on('error', function (fetch_err) {
+        console.log(fetch_err)
+        res.status(500)
+      })
+    r.pipe(fs.createWriteStream(pathName))
+    r.pipe(res)
+  }
+}
+
+function handleMetadata(req, res) {
+  var metadataUrl = decodeURIComponent(req.param('url'))
+  request
+    .get(metadataUrl)
+    .on('error', function (fetch_err) {
+      console.log("Could not fetch metadata. Sending fake Bing metadata.")
+      var parsedMetadataUrl = url.parse(metadataUrl, true)
+      var cbid = parsedMetadataUrl.query.jsonp
+      var metadata = fs.readFileSync('../offline-metadata.js', 'utf8')
+      res.send(metadata.replace('_bing_metadata_mapfilter',cbid))
+    })
+    .pipe(res)
+}
+
+module.exports = {
+  prepare: prepare,
+  proxy: handleProxy,
+  metadata: handleMetadata
+}

--- a/controllers/forms.js
+++ b/controllers/forms.js
@@ -1,5 +1,3 @@
-require('dotenv').load()
-
 var storage = require('../helpers/community-storage.js')
 var createFormList = require('openrosa-formlist')
 var persistFs = require('../helpers/persist-fs')

--- a/controllers/map-filter.js
+++ b/controllers/map-filter.js
@@ -1,19 +1,17 @@
-require('dotenv').load()
+var settings = require('../helpers/settings')
 
 var fs = require('fs')
 var path = require('path')
 var moment = require('moment')
 
-var PREFIX = process.env.data_directory
-var ROOT_PATH = path.join(PREFIX, 'Monitoring')
-var FILTERS_FOLDER = path.join(ROOT_PATH, process.env.station, 'Filters')
+const FILTERS_FOLDER = settings.getFiltersDirectory()
 
 function saveFilter (req, res, next) {
   var name = moment().format('YYYYMMDDHHmmss')
   var json = req.body
   fs.writeFile(path.join(FILTERS_FOLDER, name), JSON.stringify(json), function (err) {
     if (err) {
-      res.json({error: true, message: 'File did not save'})
+      res.json({error: true, code: 'save_failed', message: 'File did not save'})
     } else {
       res.json({error: false, message: 'Save successful'})
     }
@@ -39,24 +37,25 @@ function config (req, res, next) {
     bingProxy: '/bing-proxy',
     bingMetadata: '/bing-metadata'
   };
-  if (process.env.mapZoom) {
+  var mapFilterSettings = settings.getMapFilterSettings();
+  if (mapFilterSettings.mapZoom) {
     try {
-      data['mapZoom'] = parseInt(process.env.mapZoom, 10)
+      data['mapZoom'] = parseInt(mapFilterSettings.mapZoom, 10)
     } catch (e) {}
   }
-  if (process.env.mapCenterLat) {
+  if (mapFilterSettings.mapCenterLat) {
     try {
-      data['mapCenterLat'] = parseFloat(process.env.mapCenterLat)
+      data['mapCenterLat'] = parseFloat(mapFilterSettings.mapCenterLat)
     } catch (e) {}
   }
-  if (process.env.mapCenterLong) {
+  if (mapFilterSettings.mapCenterLong) {
     try {
-      data['mapCenterLong'] = parseFloat(process.env.mapCenterLong)
+      data['mapCenterLong'] = parseFloat(mapFilterSettings.mapCenterLong)
     } catch (e) {}
   }
   var filter = req.query.filter
   if (filter) {
-    var file = path.join(process.env.data_directory, 'Monitoring', process.env.station, 'Filters', filter)
+    var file = path.join(settings.getFiltersDirectory(), filter)
     fs.access(file, fs.F_OK | fs.R_OK, function (err) {
       if (err) {
         res.json(data)

--- a/controllers/tile-layers.js
+++ b/controllers/tile-layers.js
@@ -1,11 +1,8 @@
-require('dotenv').load()
+var settings = require('../helpers/settings')
 
 var fs = require('fs')
-var path = require('path')
 
-var PREFIX = process.env.data_directory
-var ROOT_PATH = path.join(PREFIX, 'Monitoring')
-var TILES_FOLDER = path.join(path.join(ROOT_PATH, 'Maps'), 'Tiles')
+const TILES_FOLDER = settings.getTilesDirectory()
 
 function listTileLayers (req, res, next) {
   fs.readdir(TILES_FOLDER, function (err, files) {

--- a/db/users.js
+++ b/db/users.js
@@ -1,15 +1,15 @@
-require('dotenv').load()
+var settings = require('../helpers/settings')
 
 var records = [
     { id: 1, username: 'jack', password: 'secret', displayName: 'Jack', emails: [ { value: 'jack@example.com' } ] }
   , { id: 2, username: 'jill', password: 'birthday', displayName: 'Jill', emails: [ { value: 'jill@example.com' } ] }
 ];
 
-if (process.env.shared_secret != null && process.env.shared_secret != undefined) {
+if (settings.getSharedSecret()) {
   shared = {
     id: records.length + 2,
-    username: process.env.shared_username || 'community',
-    password: process.env.shared_secret,
+    username: settings.getSharedUsername() || 'community',
+    password: settings.getSharedSecret(),
     displayName: 'Community Account',
     emails: [ { value: 'community@example.com' } ]
   };

--- a/helpers/autoconfig.js
+++ b/helpers/autoconfig.js
@@ -2,7 +2,7 @@
 process.env.directory = process.env.directory || '.'
 process.chdir(process.env.directory)
 
-require('dotenv').load()
+require('./settings').load()
 
 // Detect IP, set up defaults for configuration variables if not set
 var os = require('os')

--- a/helpers/community-storage.js
+++ b/helpers/community-storage.js
@@ -1,16 +1,14 @@
-require('dotenv').load()
+var settings = require('./settings')
 
 var fs = require('fs')
 var path = require('path')
 var mkdirp = require('mkdirp')
 
-var PREFIX = process.env.data_directory
-var ROOT_PATH = PREFIX + '/Monitoring'
-var GLOBAL_FORMS = ROOT_PATH + '/Forms'
-var GLOBAL_MAPS = ROOT_PATH + '/Maps'
+const GLOBAL_FORMS = settings.getGlobalFormsDirectory()
+const GLOBAL_MAPS = settings.getGlobalMapsDirectory()
 
 function getFormUrls (cb) {
-  var local_forms = ROOT_PATH + '/' + process.env.station + '/Forms'
+  var local_forms = settings.getUserFormsDirectory()
   fs.readdir(GLOBAL_FORMS, function (err, global) {
     fs.readdir(local_forms, function (err2, local) {
       if (err) {
@@ -21,7 +19,7 @@ function getFormUrls (cb) {
         var files = global.concat(local)
         var links = []
         for (var i = 0; i < files.length; i++) {
-          links[i] = process.env.baseUrl + '/forms/' + files[i]
+          links[i] = settings.getBaseUrl() + '/forms/' + files[i]
         }
         cb(err, links)
       }
@@ -30,7 +28,7 @@ function getFormUrls (cb) {
 }
 
 function getForm (file, cb) {
-  var local_forms = ROOT_PATH + '/' + process.env.station + '/Forms'
+  var local_forms = settings.getUserFormsDirectory()
   fs.readFile(local_forms + '/' + file, function (err, data) {
     if (err) {
       fs.readFile(GLOBAL_FORMS + '/' + file, function (err2, data2) {
@@ -43,7 +41,7 @@ function getForm (file, cb) {
 }
 
 function getMap (file, cb) {
-  var mapFile = GLOBAL_MAPS + '/' + file
+  var mapFile = path.join(GLOBAL_MAPS, file)
   fs.exists(mapFile, function (exists) {
     if (exists) {
       fs.readFile(mapFile, function (err, data) {
@@ -69,7 +67,7 @@ function getMap (file, cb) {
 }
 
 function saveMap (file, data, cb) {
-  var mapFile = GLOBAL_MAPS + '/' + file
+  var mapFile = path.join(GLOBAL_MAPS, file)
   fs.writeFile(mapFile, data, function (err) {
     cb(err)
   })

--- a/helpers/settings.js
+++ b/helpers/settings.js
@@ -1,0 +1,202 @@
+const fs = require('fs-extra');
+const path = require('path');
+const dotenv = require('dotenv');
+
+var ENV = path.join(path.dirname(__dirname), '.env')
+var LOCATION = null;
+
+function load() {
+  dotenv.load();
+
+  LOCATION = path.join(getDataDirectory(), 'Monitoring', '.settings');
+
+  var settings_contents = null;
+  try {
+    settings_contents = fs.readFileSync(LOCATION, 'utf8');
+  } catch (err) {
+    console.log("Notice: No local settings saved at " + LOCATION);
+  }
+
+  if (settings_contents) {
+    console.log("Notice: Loading local settings");
+    var settings = dotenv.parse(settings_contents)
+    Object.keys(settings).forEach(function(key) {
+      process.env[key] = settings[key];
+    });
+  }
+
+  console.log("");
+}
+
+function get(cb) {
+  var parser = function(data) {
+    var values = dotenv.parse(data);
+    values['data_directory'] = values['data_directory'] || getDataDirectory();
+    cb(null, values);
+  };
+  fs.readFile(LOCATION, 'utf8', function (err, data) {
+    if (err) {
+      fs.readFile(ENV, 'utf8', function(err, data) {
+        if (err) {
+          cb(err, null)
+        } else 
+          parser(data);
+      });
+    } else {
+      parser(data);
+    }
+  });
+}
+
+function save(settings, cb) {
+  if (LOCATION) {
+    var properties = ''
+    Object.keys(settings).forEach(function(key) {
+      if (settings[key]) {
+        properties += key + '=' + settings[key]
+        properties += '\r\n'
+      }
+      //Live-update env on save? Don't think so quite yet...
+      //process.env[key] = settings[key]
+    });
+    fs.writeFile(LOCATION, properties, 'utf8', function(err) {
+      if (err)
+        cb({error: true, code: 'saved_failed', message: 'Could not save settings', ex: err})
+      else if (settings['data_directory']) {
+        var key = 'data_directory';
+        fs.writeFile(ENV, key + '=' + settings[key], 'utf8', function(err) {
+          if (err)
+            cb({error: true, code: 'saved_failed', message: 'Could not save application settings', ex: err});
+          else
+            cb();
+        });
+      } else
+        cb();
+    });
+  } else
+    cb({error: true, code: 'fatal', message: 'No location set for settings'});
+}
+
+function getDefaultSettings() {
+  return {
+    data_directory: path.dirname(ENV),
+    station: 'DEMO',
+    locale: 'en',
+    community_lands_server: 'www.communitylands.org',
+    community_lands_port: 80,
+    community_lands_token: null,
+    port: 3000,
+    shared_secret: 'demo',
+    mapZoom: null,
+    mapCenterLat: null,
+    mapCenterLong: null
+  };
+}
+
+function getRootPath() {
+  return path.join(getDataDirectory(), 'Monitoring');
+}
+
+function getBackupDirectory() {
+  return path.join(getRootPath(), getStation(), 'Backup');
+}
+
+function getSubmissionsDirectory() {
+  return path.join(getRootPath(), getStation(), 'Submissions');
+}
+
+function getDataDirectory() {
+  return process.env.data_directory || process.env.directory;
+}
+
+function getBaseUrl() {
+  return process.env.baseUrl;
+}
+
+function getStation() {
+  return process.env.station;
+}
+
+function getCommunityLandsServer() {
+  return process.env.community_lands_server;
+}
+
+function getCommunityLandsToken() {
+  return process.env.community_lands_token;
+}
+
+function getCommunityLandsPort() {
+  return process.env.community_lands_port;
+}
+
+function getFiltersDirectory() {
+  return path.join(getRootPath(), getStation(), 'Filters')
+}
+
+function mapFilter() {
+  return {
+    mapZoom: process.env.mapZoom,
+    mapCenterLat: process.env.mapCenterLat,
+    mapCenterLong: process.env.mapCenterLong
+  };
+}
+
+function getTilesDirectory() {
+  return path.join(getRootPath(), 'Maps', 'Tiles');
+}
+
+function getGlobalMapsDirectory() {
+  return path.join(getRootPath(), 'Maps');
+}
+
+function getGlobalFormsDirectory() {
+  return path.join(getRootPath(), 'Forms');
+}
+
+function getUserFormsDirectory() {
+  return path.join(getRootPath(), getStation(), 'Forms');
+}
+
+function getSharedSecret() {
+  return process.env.shared_secret;
+}
+
+function getSharedUsername() {
+  return process.env.shared_username;
+}
+
+function getPort() {
+  return process.env.port;
+}
+
+function getLocale() {
+  return process.env.locale;
+}
+
+module.exports = {
+
+  load: load,
+  get: get,
+  save: save,
+  defaults: getDefaultSettings(),
+  getDataDirectory: getDataDirectory,
+  getBackupDirectory: getBackupDirectory,
+  getSubmissionsDirectory: getSubmissionsDirectory,
+  getBaseUrl: getBaseUrl,
+  getStation: getStation,
+  getCommunityLandsServer: getCommunityLandsServer,
+  getCommunityLandsToken: getCommunityLandsToken,
+  getCommunityLandsPort: getCommunityLandsPort,
+  getFiltersDirectory: getFiltersDirectory,
+  getMapFilterSettings: mapFilter,
+  getTilesDirectory: getTilesDirectory,
+  getGlobalMapsDirectory: getGlobalMapsDirectory,
+  getGlobalFormsDirectory: getGlobalFormsDirectory,
+  getUserFormsDirectory: getUserFormsDirectory,
+  getSharedSecret: getSharedSecret,
+  getSharedUsername: getSharedUsername,
+  getRootPath: getRootPath,
+  getPort: getPort,
+  getLocale: getLocale
+
+}

--- a/middlewares/append-geojson.js
+++ b/middlewares/append-geojson.js
@@ -1,10 +1,5 @@
-require('dotenv').load()
-
 var storage = require('../helpers/community-storage.js')
 
-var PREFIX = process.env.data_directory;
-var ROOT_PATH = PREFIX + '/Monitoring';
-var SUBMISSIONS = ROOT_PATH + '/' + process.env.station + '/Submissions';
 var MAP = 'Monitoring.geojson';
 
 /**

--- a/middlewares/process-submission.js
+++ b/middlewares/process-submission.js
@@ -1,16 +1,15 @@
-require('dotenv').load()
+var settings = require('../helpers/settings')
 
 var xform2json = require('xform-to-json')
 var extend = require('xtend')
 var fmt = require('moment')
+var path = require('path')
 
 var defaults = {
   geojson: true
 }
 
-var PREFIX = process.env.data_directory
-var ROOT_PATH = PREFIX + '/Monitoring'
-var SUBMISSIONS = ROOT_PATH + '/' + process.env.station + '/Submissions'
+var SUBMISSIONS = settings.getSubmissionsDirectory()
 
 /**
  * Converts form xml in `req.body` to json, adds meta data, attaches data to
@@ -41,7 +40,7 @@ function ProcessSubmission (options) {
         geojson: options.geojson,
         xml: req.body,
         date: date,
-        location: SUBMISSIONS + '/' + req.user.username + '/' + date + '/',
+        location: path.join(SUBMISSIONS, req.user.username, date) + '/',
         formId: meta.formId,
         instanceId: meta.instanceId.replace(/^uuid:/, '')
       }

--- a/server.js
+++ b/server.js
@@ -10,6 +10,8 @@ var request = require('request')
 var db = require('./db')
 var url = require('url')
 
+var settings = require('./helpers/settings')
+
 // var tile_cache = require('./helpers/tile-cache')
 // tile_cache.pyramid_urls(-76.3605,-9.4491,-72.757,-6.1078, 1, 13)
 
@@ -96,7 +98,7 @@ app.get('/bing-proxy/:url', function (req, res) {
   }
 })
 
-app.use('/monitoring-files', express.static(path.join(process.env.data_directory, 'Monitoring')))
+app.use('/monitoring-files', express.static(settings.getRootPath()))
 
 app.get('/',
   function (req, res) {
@@ -161,6 +163,6 @@ app.post('/submission',
 
 app.use(error)
 
-var port = process.env.port
+var port = settings.getPort()
 app.listen(port)
 console.log('Listening on port %s', port)


### PR DESCRIPTION
The .env file now lists your data directory only; the rest of
the users settings are stored in the data dir.

Refactored all calls to process.env.\* for settings information
to call helper functions from helpers/settings.js. The functions
here simply wrap calls to process.env.*, but using this class
makes things more portable should another direction be taken
later, and future changes (i.e. moving the settings file again)
will keep the rest of the app working.

Also removed excess calls to dotenv.load, as this only needs to
be called once, at app startup.  Now called in settings.load.
