### PR TITLE
Read default base layer from save maps.

### DIFF
--- a/controllers/map-filter.js
+++ b/controllers/map-filter.js
@@ -72,7 +72,10 @@ function config (req, res, next) {
         res.json(data)
       } else {
         fs.readFile(file, 'utf8', function (err, contents) {
-          data['filters'] = JSON.parse(contents).value
+          var filterJson = JSON.parse(contents)
+          data['filters'] = filterJson.value
+          if (filterJson.baseLayer)
+            data['baseLayer'] = filterJson.baseLayer
           res.json(data)
         })
       }


### PR DESCRIPTION
Local maps can now store their preferred base layer with
the configuration settings. Set this property in the config
route when loading from a filter.

Currently, this is language-specific, and will need further
work if we want this to be compatible across languages.
