### PR TITLE
Update settings page to new interface style.

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,10 +195,11 @@
       var html = '<form>';
       for (var key in sections) {
         if (sections[key] != '') {
-          html += '<h6 class="text-uppercase" style="letter-spacing: 1px; font-weight: 700; color: #959595">';
+          //html += '<h4 class="text-uppercase" style="letter-spacing: 1px; font-weight: 700; color: #959595">';
+          html += '<h4>';
           html += t("subtitle.settings."  + key);
-          html += '</h6>';
-          html += sections[key];
+          html += '</h4>';
+          html += '<div class="well">' + sections[key] + '</div>';
         }
       }
       html += "</form>";
@@ -253,6 +254,7 @@
       else
         document.getElementById('import_status').innerHTML = t('text.import_success');
     });
+
     ipc.send('show_configuration');
     ipc.send('check_last_backup');
     ipc.send('form_list');
@@ -426,14 +428,13 @@
         </div>
 
         <div role="tabpanel" class="tab-pane" id="advanced-settings">
-          <h4><i class="fa fa-gears fa-lg" aria-hidden="true"></i> <span data-translate="title.settings">Settings</span></h4>
-          <div class="well">
-            <div id="settings_form">
+          <!--<h4><i class="fa fa-gears fa-lg" aria-hidden="true"></i> <span data-translate="title.settings">Settings</span></h4>-->
+          <div id="settings_form">
 
-            </div>
-            <button onclick="javascript:saveSettings();" class="btn btn-small btn-primary"><span style='margin-right:5px' data-translate="button.update_settings">Update Settings</span><i class="fa fa-gear" aria-hidden="true"></i></button>
-            <div id="settings_status"></div>
           </div>
+          <button onclick="javascript:saveSettings();" class="btn btn-small btn-primary"><span style='margin-right:5px' data-translate="button.update_settings">Update Settings</span><i class="fa fa-gear" aria-hidden="true"></i></button>
+          <div id="settings_status"></div>
+          <div class="clearfix">&nbsp;</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Changed the h6's to h4's, removed the gray coloring, and
shifted the sections into their on wells, such that the
interface is consistent with the other tabs.

Also, added clearfix to the bottom of the page to compensate
for this change and keep the save button from the bottom of
the page.

Finally, removed the Application Settings header, as this now
seems superfluous. Left commented if needed back.
