### PR TITLE
Report community lands upload progress.

### DIFF
--- a/application/data/en.json
+++ b/application/data/en.json
@@ -84,7 +84,8 @@
     "progress": {
         "uploading": "Uploading, please wait...",
         "saving": "Saving files, please wait...",
-        "importing": "Importing files, please wait..."
+        "importing": "Importing files, please wait...",
+        "waiting": "Upload complete, processing files"
     },
     "alert": {
         "no_internet": "No internet connection detected",

--- a/helpers/server-events.js
+++ b/helpers/server-events.js
@@ -1,0 +1,5 @@
+var events = require('events');
+
+const bus = new events.EventEmitter();
+
+module.exports = bus;

--- a/index.html
+++ b/index.html
@@ -253,6 +253,14 @@
       else
         document.getElementById('import_status').innerHTML = t('text.import_success');
     });
+    ipc.on('cl_upload_progress', function(evt, result) {
+      if (result.status == "uploading")
+        document.getElementById('community_lands_sync_status').innerHTML = t('progress.importing') + " -- " + result.progress + "...";
+      else
+        document.getElementById('community_lands_sync_status').innerHTML = t('progress.importing') + " -- " + t('progress.' + result.status) +
+          ' <i class="fa fa-spinner fa-pulse fa-fw"></i>'
+    });
+
     ipc.send('show_configuration');
     ipc.send('check_last_backup');
     ipc.send('form_list');

--- a/main.js
+++ b/main.js
@@ -7,6 +7,25 @@ const dialog = electron.dialog
 
 require('./server')
 var settings = require('./helpers/settings')
+var ServerEvents = require('./helpers/server-events')
+ServerEvents.on('cl_upload_progress', function(done, bytes) {
+  if (done)
+    mainWindow.send('cl_upload_progress', { status: 'waiting' });
+  else {
+    var value = bytes, units = 'B';
+    if (bytes < 1024) {
+      //Do nothing
+    } else if (bytes < (1024 * 1024)) {
+      value = bytes / 1024;
+      units = 'KB';
+    } else {
+      value = bytes / (1024 * 1024);
+      units = 'MB';
+    }
+    value = +value.toFixed(2);
+    mainWindow.send('cl_upload_progress', { status: 'uploading', progress: value + ' ' + units });
+  }
+});
 
 var http = require('http')
 var fs = require('fs-extra')


### PR DESCRIPTION
Added a ServerEvent module responsible for transmitting
event information from the server to the main process. Then,
added a check on the Community Lands backup call to fire
events regarding the status of the upload. This information
is listened for and displayed to the client.

This information is regarding the upload progress ONLY; that
is to say, once the file is uploaded to Community Lands, no
further updates will be given until Community Lands has
processed the zip file and the request has completed.
