### PR TITLE
Display listing and help text for local tiles.

### DIFF
--- a/application/data/en.json
+++ b/application/data/en.json
@@ -9,6 +9,7 @@
         "last_synchronized": "Last Synchronized: ",
         "last_backup": "Last Backup: ",
         "open": "Open: ",
+        "tiles_folder": "Folder for local Map Tiles:",
         "settings": {
             "data_directory": "Data Directory",
             "shared_secret": "Shared Secret",
@@ -40,6 +41,9 @@
         "backup": {
             "simple": "Store a ZIP file backup of monitoring data to the application folder",
             "usb": "Create a backup and save it to your location of choice, like a USB drive"
+        },
+        "tiles": {
+            "usage": "To add new sets of tiles, create a subfolder in this directory with a name of your choosing, and copy tiles into this new folder. The folder name will be displayed in MapFilter as a map layer."
         }
     },
     "confirm": {
@@ -59,6 +63,7 @@
         "community_lands": "Community Lands",
         "my_monitoring_forms": "My Monitoring Forms",
         "saved_filters": "Saved Maps",
+        "saved_tiles": "Local Map Tiles",
         "settings": "Application Settings"
     },
     "subtitle": {
@@ -110,6 +115,8 @@
         "community_lands_not_configured": "Community Lands connection not configured",
         "import_delete_failed": "Could not overwrite files",
         "import_unzip_failed": "Could not unzip import file",
-        "backup_failed": "Could not backup data"
+        "backup_failed": "Could not backup data",
+        "files_in_tiles_folder": "There are files in the Tiles folder; only subfolders should exist here.",
+        "numeric_folder_in_tiles_folder": "Some subfolders appear to be misplaced; perhaps you forgot to create a subfolder under Tiles?"
     }
 }

--- a/controllers/tile-layers.js
+++ b/controllers/tile-layers.js
@@ -1,11 +1,10 @@
 var settings = require('../helpers/settings')
 
-var fs = require('fs')
-
-const TILES_FOLDER = settings.getTilesDirectory()
+var fs = require('fs'),
+  path = require('path')
 
 function listTileLayers (req, res, next) {
-  fs.readdir(TILES_FOLDER, function (err, files) {
+  fs.readdir(settings.getTilesDirectory(), function (err, files) {
     if (err) {
       res.json(500, {
         message: err.message,
@@ -14,11 +13,20 @@ function listTileLayers (req, res, next) {
     } else {
       var names = []
       for (var index in files) {
-        names.push({name: files[index]})
+        var file = files[index];
+        var stats = fs.statSync(path.join(settings.getTilesDirectory(), file));
+        if (stats.isDirectory() && !isInt(file))
+          names.push({name: file});
       }
+      names.sort(function(a, b) { return a < b ? -1 : a > b ? 1 : 0 });
       res.json(names)
     }
   })
+}
+
+function isInt(value) {
+  var check = parseInt(value)
+  return (!isNaN(value) && (check | 0) === check)
 }
 
 module.exports = {

--- a/index.html
+++ b/index.html
@@ -87,6 +87,32 @@
         document.getElementById('form_listing').innerHTML = "";
       }
     });
+    ipc.on('has_tiles_list', function(evt, result) {
+      document.getElementById('tiles_listing').innerHTML = "";
+      if (!result.error) {
+        var content = '';
+        var tiles = result.tiles;
+        if (tiles.length > 0) {
+          var content = '<h5>' + t('title.saved_tiles') + '</h5>';
+          content += '<table class="table table-condensed">';
+          for (var i in tiles) {
+            content += '<tr>';
+            content += '<td>' + tiles[i] + '</td>';
+            content += '</tr>';
+          }
+          content += '</table>';
+        }
+        if (result.warnings && result.warnings.length > 0) {
+          content += '<div style="margin-top: 10px">';
+          for (var i in result.warnings) {
+            var warning = result.warnings[i];
+            content += '<div class="text-warning"><i class="fa fa-warning"></i> <span>' + t(warning) + '</span></div>';
+          }
+          content += '</div>';
+        }
+        document.getElementById('tiles_listing').innerHTML = content;
+      }
+    });
     ipc.on('has_filter_list', function(evt, result) {
       document.getElementById('saved-filters').innerHTML = "";
       var json = JSON.parse(result);
@@ -266,6 +292,8 @@
       document.getElementById('mapUrl').innerHTML = '<a id="mapUrlLink" href="' + configuration.baseUrl + '/mapfilter?locale=' +
         configuration.locale + '">' + configuration.baseUrl + '/mapfilter</a>';
       document.getElementById('form_folder').innerHTML = configuration.directory + "/Monitoring/" + configuration.station + "/Forms"
+      document.getElementById('track_folder').innerHTML = configuration.tracks;
+      document.getElementById('tiles_folder').innerHTML = configuration.tiles;
       if (configuration.community_lands == true)
         document.getElementById('community_lands_content').className = "";
       document.getElementById('mapUrlLink').onclick = function(evt) {
@@ -304,6 +332,7 @@
     ipc.send('form_list');
     ipc.send('filter_list');
     ipc.send('settings_list');
+    ipc.send('tiles_list');
 
     window.addEventListener('online',  updateOnlineStatus);
     window.addEventListener('offline',  updateOnlineStatus);
@@ -466,6 +495,16 @@
             </div>
             <h5 data-translate="title.new_form">Add New Form</h5>
             <button onclick="javascript:selectForm();" class="btn btn-small btn-primary"><span style='margin-right:5px' data-translate="button.select_file">Select from File</span><i class="fa fa-file-o" aria-hidden="true"></i></button>
+          </div>
+          <h4><i class="fa fa-map fa-lg" aria-hidden="true"></i> &#160; <span data-translate="title.tiles"></span></h4>
+          <div class="well">
+            <div data-translate="prompt.tiles_folder">
+              Folder for custom Map Tiles:
+            </div>
+            <div><b id="tiles_folder"></b></div>
+            <div data-translate="help.tiles.usage" class="help-block"></div>
+            <div id="tiles_listing" style="margin-top:20px">
+            </div>
           </div>
           <h4><i class="fa fa-map-marker fa-lg" aria-hidden="true"></i> &#160; <span data-translate="title.GPS_track_data">GPS Track Data</span></h4>
           <div class="well">


### PR DESCRIPTION
List what's stored in `Monitoring/Maps/Tiles` and provide
usage details; also, warn when the folder contains something
that seems to not belong.

Also, populate the `tracks_folder` with the appropriate directory.
