### PR TITLE
Quiet zip, file exclusion for build scripts.

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -5,6 +5,6 @@ electron-packager `pwd` MonitoringStation --platform=darwin --arch=x64 --out bui
 cd builds
 # zip -r MonitoringStation-darwin-x64-1.0.0.zip MonitoringStation-darwin-x64
 cd MonitoringStation-darwin-x64
-zip -r MonitoringStation.zip .
+zip -q -r --exclude=*.git* --exclude=*.DS_Store* --exclude=*.env* --exclude=*build*.sh* MonitoringStation.zip .
 cd ..
 cd ..

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,6 @@ electron-packager `pwd` MonitoringStation --platform=win32 --arch=x64 --out buil
 cd builds
 # zip -r MonitoringStation-darwin-x64-1.0.0.zip MonitoringStation-darwin-x64
 cd MonitoringStation-win32-x64
-zip -r MonitoringStation.zip .
+zip -q -r --exclude=*.git* --exclude=*.DS_Store* --exclude=*.env* --exclude=*build*.sh* MonitoringStation.zip .
 cd ..
 cd ..


### PR DESCRIPTION
Exclude the DS_Store, .git directory, and, most importantly,
the .env file when zipping up a build. Also, tone down the
noice from the zip operation.
