### PR TITLE
Move the CMS features out to a module

### DIFF
--- a/application/actions.js
+++ b/application/actions.js
@@ -15,12 +15,12 @@ try {
 }
 
 const electron = require('electron')
-
 const ipc = electron.ipcRenderer
 const shell = electron.shell
-
 const remote = electron.remote
 const {Menu, MenuItem} = remote
+
+require('./application/cms')
 
 const menu = new Menu()
 menu.append(new MenuItem({
@@ -221,9 +221,6 @@ ipc.on('has_community_lands_backup', function (evt, result) {
   showStatus(html, { type: json.error ? 'error' : 'success', timeout: 10000 })
   ipc.send('community_lands_status')
 })
-ipc.on('has_saved_template', function (evt, result) {
-  hideLoadingScreen()
-})
 ipc.on('has_settings_list', function (evt, settings) {
   var sections = {
     general: '',
@@ -410,7 +407,10 @@ window.addEventListener('offline', updateOnlineStatus)
 
 updateOnlineStatus()
 
-/* FIXME: convert this to a module and export this functionality */
+/* FIXME: convert this to a module and export this functionality. The
+   window.foo = foo declarations here are redundant, but make the linter
+   happy so it's easier to see brokenness.
+ */
 
 function communityLandsUpload () {
   if (navigator.onLine) {
@@ -420,36 +420,32 @@ function communityLandsUpload () {
     alert(t('alert.no_internet'))
   }
 }
+window.communityLandsUpload = communityLandsUpload
 
 function backupFiles (cb) {
   showLoadingScreen(t('progress.saving'))
   ipc.send('backup_submissions', cb)
 }
+window.backupFiles = backupFiles
 
 function importFilesOverwrite () {
   showLoadingScreen(t('progress.importing'))
   ipc.send('import_files', { mode: 'overwrite' })
 }
+window.importFilesOverwrite = importFilesOverwrite
 
 function importFilesMerge () {
   showLoadingScreen(t('progress.importing'))
   ipc.send('import_files', { mode: 'merge' })
 }
-
-function saveTemplate () {
-  showLoadingScreen(t('progress.saving_template'))
-  ipc.send('save_template', {
-    template: document.getElementById('select_website_template').value,
-    community: document.getElementById('website_community').value,
-    year: document.getElementById('website_year').value
-  })
-}
+window.importFilesMerge = importFilesMerge
 
 function openBackupFile () {
   var file = document.getElementById('backup_file')
     .getAttribute('data-location')
   shell.showItemInFolder(file)
 }
+window.openBackupFile = openBackupFile
 
 function openBackupFolder () {
   if (config) {
@@ -457,10 +453,12 @@ function openBackupFolder () {
       '/Backup')
   }
 }
+window.openBackupFolder = openBackupFolder
 
 function selectForm () {
   ipc.send('select_form')
 }
+window.selectForm = selectForm
 
 function translatePage () {
   var tags = ['h4', 'h5', 'div', 'span', 'b', 'button']
@@ -473,10 +471,12 @@ function translatePage () {
     }
   }
 }
+window.selectForm = translatePage
 
 function chooseDataDirectory () {
   ipc.send('select_data_directory')
 }
+window.chooseDataDirectory = chooseDataDirectory
 
 function saveSettings () {
   showLoadingScreen(t('progress.saving'))
@@ -491,6 +491,7 @@ function saveSettings () {
   }
   ipc.send('settings_save', object)
 }
+window.saveSettings = saveSettings
 
 function enableCopyPaste (selection) {
   $(selection).each(function (index, el) {
@@ -501,3 +502,4 @@ function enableCopyPaste (selection) {
     }, false)
   })
 }
+window.enableCopyPaste = enableCopyPaste

--- a/application/actions.js
+++ b/application/actions.js
@@ -4,9 +4,8 @@
 /* global showStatus */
 /* global showLoadingScreen, updateLoadingScreen, hideLoadingScreen */
 
-window.locale.en = require('./application/data/en')
-window.locale.es = require('./application/data/es')
-window.locale.init()
+require('./application/locale')
+require('./application/loading')
 
 try {
   window.appVersion = require('./application/data/version')

--- a/application/actions.js
+++ b/application/actions.js
@@ -1,11 +1,10 @@
 /* eslint-env browser, jquery */
-/* FIXME: these globals can and should be done with requires */
-/* global t, t_exists */
-/* global showStatus */
-/* global showLoadingScreen, updateLoadingScreen, hideLoadingScreen */
 
-require('./application/locale')
-require('./application/loading')
+const locale = require('./application/locale')
+const t = locale.t
+const t_exists = locale.t_exists
+
+const loading = require('./application/loading')
 
 try {
   window.appVersion = require('./application/data/version')
@@ -47,11 +46,11 @@ var updateOnlineStatus = function () {
   ipc.send('community_lands_online', navigator.onLine)
 }
 ipc.on('backup_submissions_complete', function (evt, json) {
-  hideLoadingScreen()
+  loading.hideLoadingScreen()
   if (json.error) {
     alert(t('error.' + json.code))
   } else if (!json.cancelled) {
-    showStatus(t('text.backup_complete') +
+    loading.showStatus(t('text.backup_complete') +
       '<br/>' + t('prompt.open') +
       '<a id="backup_file" href="javascript:openBackupFile();" ' +
       'data-location="' + json.location + '">' + json.location +
@@ -200,7 +199,7 @@ ipc.on('has_community_lands_status', function (evt, result) {
   }
 })
 ipc.on('has_community_lands_backup', function (evt, result) {
-  hideLoadingScreen()
+  loading.hideLoadingScreen()
   var json = JSON.parse(result)
   var html = ''
   if (json.error) {
@@ -217,7 +216,9 @@ ipc.on('has_community_lands_backup', function (evt, result) {
     html += ' '
     html += json.entity.files_uploaded
   }
-  showStatus(html, { type: json.error ? 'error' : 'success', timeout: 10000 })
+  loading.showStatus(html, {
+    type: json.error ? 'error' : 'success', timeout: 10000
+  })
   ipc.send('community_lands_status')
 })
 ipc.on('has_settings_list', function (evt, settings) {
@@ -364,31 +365,31 @@ ipc.on('has_select_data_directory', function (evt, folder) {
   document.getElementById('settings-form-data_directory').value = folder
 })
 ipc.on('has_settings_save', function (evt, result) {
-  hideLoadingScreen()
+  loading.hideLoadingScreen()
   var json = JSON.parse(result)
   if (json.error) {
-    showStatus(t('error.' + json.code), { type: 'error' })
+    loading.showStatus(t('error.' + json.code), { type: 'error' })
   } else {
-    showStatus(
+    loading.showStatus(
       t('message.settings_saved'),
       { timeout: false, type: 'warning' }
     )
   }
 })
 ipc.on('has_import_files', function (evt, result) {
-  hideLoadingScreen()
+  loading.hideLoadingScreen()
   if (result.error) {
-    showStatus(t('error.' + result.code), { type: 'error' })
+    loading.showStatus(t('error.' + result.code), { type: 'error' })
   } else {
-    showStatus(t('text.import_success'), { timeout: 5000 })
+    loading.showStatus(t('text.import_success'), { timeout: 5000 })
   }
 })
 ipc.on('cl_upload_progress', function (evt, result) {
   if (result.status === 'uploading') {
-    updateLoadingScreen(t('progress.importing') + ' <br/> &gt; ' +
+    loading.updateLoadingScreen(t('progress.importing') + ' <br/> &gt; ' +
       result.progress + '...')
   } else {
-    updateLoadingScreen(t('progress.importing') + ' <br/> &gt; ' +
+    loading.updateLoadingScreen(t('progress.importing') + ' <br/> &gt; ' +
       t('progress.' + result.status) +
       ' <i class="fa fa-spinner fa-pulse fa-fw"></i>')
   }
@@ -413,7 +414,7 @@ updateOnlineStatus()
 
 function communityLandsUpload () {
   if (navigator.onLine) {
-    showLoadingScreen(t('progress.uploading'))
+    loading.showLoadingScreen(t('progress.uploading'))
     ipc.send('community_lands_backup')
   } else {
     alert(t('alert.no_internet'))
@@ -422,19 +423,19 @@ function communityLandsUpload () {
 window.communityLandsUpload = communityLandsUpload
 
 function backupFiles (cb) {
-  showLoadingScreen(t('progress.saving'))
+  loading.showLoadingScreen(t('progress.saving'))
   ipc.send('backup_submissions', cb)
 }
 window.backupFiles = backupFiles
 
 function importFilesOverwrite () {
-  showLoadingScreen(t('progress.importing'))
+  loading.showLoadingScreen(t('progress.importing'))
   ipc.send('import_files', { mode: 'overwrite' })
 }
 window.importFilesOverwrite = importFilesOverwrite
 
 function importFilesMerge () {
-  showLoadingScreen(t('progress.importing'))
+  loading.showLoadingScreen(t('progress.importing'))
   ipc.send('import_files', { mode: 'merge' })
 }
 window.importFilesMerge = importFilesMerge
@@ -478,7 +479,7 @@ function chooseDataDirectory () {
 window.chooseDataDirectory = chooseDataDirectory
 
 function saveSettings () {
-  showLoadingScreen(t('progress.saving'))
+  loading.showLoadingScreen(t('progress.saving'))
   var els = document.getElementsByClassName('key-value')
   var object = {}
   for (var i = 0; i < els.length; i++) {

--- a/application/actions.js
+++ b/application/actions.js
@@ -471,7 +471,7 @@ function translatePage () {
     }
   }
 }
-window.selectForm = translatePage
+window.translatePage = translatePage
 
 function chooseDataDirectory () {
   ipc.send('select_data_directory')

--- a/application/cms.js
+++ b/application/cms.js
@@ -1,0 +1,23 @@
+/* eslint-env browser, jquery */
+
+const electron = require('electron')
+const ipc = electron.ipcRenderer
+const loading = require('./loading.js')
+const t = require('./locale.js').t
+
+const saveTemplate = () => {
+  loading.showLoadingScreen(t('progress.saving_template'))
+  ipc.send('save_template', {
+    template: $('#select_website_template').val(),
+    community: $('#website_community').val(),
+    year: $('#website_year').val()
+  })
+}
+
+ipc.on('has_saved_template', function (evt, result) {
+  loading.hideLoadingScreen()
+})
+
+$(function () {
+  $('#cmsSaveTemplateButton').on('click', saveTemplate)
+})

--- a/application/loading.js
+++ b/application/loading.js
@@ -1,4 +1,46 @@
-var statusIcons = { success: 'check-circle', warning: 'exclamation-circle', danger: 'times-circle', info: 'info-circle' };
+/* eslint-env browser, jquery */
+/* FIXME: these globals can and should be done with requires */
+/* global t */
+
+var statusIcons = {
+  success: 'check-circle',
+  warning: 'exclamation-circle',
+  danger: 'times-circle',
+  info: 'info-circle'
+}
+
+/**
+ * Call on a loading screen being displayed to update
+ * the status line
+ *
+ * Options - a status message (string) or a hash:
+ * - heading: change the heading message
+ * - status: change the status message
+ *
+ */
+function updateLoadingScreen (opts) {
+  var options
+  if (typeof opts === 'string') {
+    options = { status: opts }
+  } else {
+    options = opts
+  }
+
+  if (options['heading']) {
+    jQuery('#loading .modal-title').html(options.heading)
+  }
+
+  if (options['status']) {
+    jQuery('#loading-status').html(options.status)
+  }
+}
+/* TODO: for backwards compatibility, we still define these functions
+   in the global namespace ("function foo(){}") -- but also expose them
+   as exports so code going forward can use these features as a module.
+   Eventually, take away the global usages. */
+if (typeof exports !== 'undefined') {
+  exports.updateLoadingScreen = updateLoadingScreen
+}
 
 /**
  * Display the loading screen
@@ -7,48 +49,31 @@ var statusIcons = { success: 'check-circle', warning: 'exclamation-circle', dang
  * - heading: the heading message (default t('progress.loading'))
  * - status: the status message (default blank)
  */
-function showLoadingScreen(opts) {
-  var options;
+function showLoadingScreen (opts) {
+  var options
 
-  if (opts !== undefined && typeof opts == 'string')
-    options = { heading: opts };
-  else {
-    options = opts || {};
-    options['heading'] = options['heading'] || t('progress.loading');
-    options['status'] = options['status'] || null;
+  if (opts !== undefined && typeof opts === 'string') {
+    options = { heading: opts }
+  } else {
+    options = opts || {}
+    options['heading'] = options['heading'] || t('progress.loading')
+    options['status'] = options['status'] || null
   }
 
-  updateLoadingScreen(options);
+  updateLoadingScreen(options)
 
-  $("#loading-status").html("");
-  $("#loading").modal('show');
+  $('#loading-status').html('')
+  $('#loading').modal('show')
+}
+if (typeof exports !== 'undefined') {
+  exports.showLoadingScreen = showLoadingScreen
 }
 
-/**
- * Call on a loading screen being displayed to update 
- * the status line
- * 
- * Options - a status message (string) or a hash:
- * - heading: change the heading message
- * - status: change the status message
- *
- */
-function updateLoadingScreen(opts) {
-  var options;
-  if (typeof opts == 'string')
-    options = { status: opts }
-  else
-    options = opts;
-
-  if (options['heading'])
-    jQuery("#loading .modal-title").html(options.heading);
-
-  if (options['status'])
-    jQuery("#loading-status").html(options.status);
+function hideLoadingScreen () {
+  $('#loading').modal('hide')
 }
-
-function hideLoadingScreen() {
-  $("#loading").modal('hide');
+if (typeof exports !== 'undefined') {
+  exports.hideLoadingScreen = hideLoadingScreen
 }
 
 /**
@@ -57,41 +82,50 @@ function hideLoadingScreen() {
  * - timeout: when dismissable is true, true to auto-dismiss the alert, false otherwise (default true)
  * - type: One of "success", "info", "warning" or "danger" (defaults to "success")
  */
-function showStatus(message, opts) {
-  var options = opts || {};
-  options['type'] = options['type'] || 'success';
-  if (options.type == 'error')
-    options.type = 'danger';
-
-  var dismissable = options['dismissable'] != false;
-  var html = '';
-
-  var status = $("#status");
-
-  html += '<div role="alert" class="alert alert-' + options.type;
-  if (dismissable)
-    html += ' alert-dismissable fade in';
-  html += '">';
-
-  if (dismissable)
-    html += '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>';
-
-  if (options['icon'] != false) {
-    var icon = (typeof options['icon'] == 'string') ? options.icon : statusIcons[options.type];
-    html += '<i class="fa fa-' + icon + '"></i>&nbsp;';
+function showStatus (message, opts) {
+  var options = opts || {}
+  options['type'] = options['type'] || 'success'
+  if (options.type === 'error') {
+    options.type = 'danger'
   }
 
-  html += message;
+  var dismissable = options['dismissable'] !== false
+  var html = ''
 
-  html += '</div>';
+  var status = $('#status')
 
-  status.html(html);
-
-  status.show();
-  $("html body").animate({ scrollTop: 0 });
-
-  if (dismissable && options['timeout'] != false) {
-    var timeout = (typeof options['timeout'] == 'number') ? options.timeout : 3000;
-    setTimeout(function() { $("#status .alert").alert('close'); }, timeout);
+  html += '<div role="alert" class="alert alert-' + options.type
+  if (dismissable) {
+    html += ' alert-dismissable fade in'
   }
+  html += '">'
+
+  if (dismissable) {
+    html += '<button type="button" class="close" data-dismiss="alert" ' +
+      'aria-label="Close"><span aria-hidden="true">&times;</span></button>'
+  }
+
+  if (options['icon'] !== false) {
+    var icon = (typeof options['icon'] === 'string') ? options.icon : statusIcons[options.type]
+    html += '<i class="fa fa-' + icon + '"></i>&nbsp;'
+  }
+
+  html += message
+
+  html += '</div>'
+
+  status.html(html)
+
+  status.show()
+  $('html body').animate({ scrollTop: 0 })
+
+  if (dismissable && options['timeout'] !== false) {
+    var timeout = (typeof options['timeout'] === 'number') ? options.timeout : 3000
+    setTimeout(function () {
+      $('#status .alert').alert('close')
+    }, timeout)
+  }
+}
+if (typeof exports !== 'undefined') {
+  exports.showStatus = showStatus
 }

--- a/application/loading.js
+++ b/application/loading.js
@@ -18,7 +18,7 @@ var statusIcons = {
  * - status: change the status message
  *
  */
-function updateLoadingScreen (opts) {
+exports.updateLoadingScreen = (opts) => {
   var options
   if (typeof opts === 'string') {
     options = { status: opts }
@@ -34,13 +34,6 @@ function updateLoadingScreen (opts) {
     jQuery('#loading-status').html(options.status)
   }
 }
-/* TODO: for backwards compatibility, we still define these functions
-   in the global namespace ("function foo(){}") -- but also expose them
-   as exports so code going forward can use these features as a module.
-   Eventually, take away the global usages. */
-if (typeof exports !== 'undefined') {
-  exports.updateLoadingScreen = updateLoadingScreen
-}
 
 /**
  * Display the loading screen
@@ -49,7 +42,7 @@ if (typeof exports !== 'undefined') {
  * - heading: the heading message (default t('progress.loading'))
  * - status: the status message (default blank)
  */
-function showLoadingScreen (opts) {
+exports.showLoadingScreen = (opts) => {
   var options
 
   if (opts !== undefined && typeof opts === 'string') {
@@ -60,20 +53,14 @@ function showLoadingScreen (opts) {
     options['status'] = options['status'] || null
   }
 
-  updateLoadingScreen(options)
+  exports.updateLoadingScreen(options)
 
   $('#loading-status').html('')
   $('#loading').modal('show')
 }
-if (typeof exports !== 'undefined') {
-  exports.showLoadingScreen = showLoadingScreen
-}
 
-function hideLoadingScreen () {
+exports.hideLoadingScreen = () => {
   $('#loading').modal('hide')
-}
-if (typeof exports !== 'undefined') {
-  exports.hideLoadingScreen = hideLoadingScreen
 }
 
 /**
@@ -82,7 +69,7 @@ if (typeof exports !== 'undefined') {
  * - timeout: when dismissable is true, true to auto-dismiss the alert, false otherwise (default true)
  * - type: One of "success", "info", "warning" or "danger" (defaults to "success")
  */
-function showStatus (message, opts) {
+exports.showStatus = (message, opts) => {
   var options = opts || {}
   options['type'] = options['type'] || 'success'
   if (options.type === 'error') {
@@ -126,6 +113,10 @@ function showStatus (message, opts) {
     }, timeout)
   }
 }
-if (typeof exports !== 'undefined') {
-  exports.showStatus = showStatus
-}
+
+/* FIXME: for backwards compatibility, we copy these exports onto
+   the window object. Remove this when this is no longer needed. */
+window.updateLoadingScreen = exports.updateLoadingScreen
+window.showLoadingScreen = exports.showLoadingScreen
+window.hideLoadingScreen = exports.hideLoadingScreen
+window.showStatus = exports.showStatus

--- a/application/locale.js
+++ b/application/locale.js
@@ -1,6 +1,7 @@
 /* eslint-env browser, jquery */
-
-var QueryString = (
+/* FIXME: This module still pollutes global namespace for backwards
+   compatibility. */
+const QueryString = (
   function () {
     var query_string = {}
     var query = window.location.search.substring(1)
@@ -20,8 +21,7 @@ var QueryString = (
   }()
 )
 
-var locale = { _current: 'en' }
-window.locale = locale
+const locale = { _current: 'en' }
 
 window.QueryString = QueryString
 
@@ -120,3 +120,9 @@ window.t = function (s, o, loc) {
   }
 }
 if (typeof exports !== 'undefined') { exports.t = window.t }
+
+locale.en = require('./data/en')
+locale.es = require('./data/es')
+locale.init()
+
+window.locale = locale

--- a/application/locale.js
+++ b/application/locale.js
@@ -1,106 +1,122 @@
-var QueryString = function () {
-  var query_string = {};
-  var query = window.location.search.substring(1);
-  var vars = query.split("&");
-  for (var i=0;i<vars.length;i++) {
-    var pair = vars[i].split("=");
-    if (typeof query_string[pair[0]] === "undefined") {
-      query_string[pair[0]] = decodeURIComponent(pair[1]);
-    } else if (typeof query_string[pair[0]] === "string") {
-      var arr = [ query_string[pair[0]],decodeURIComponent(pair[1]) ];
-      query_string[pair[0]] = arr;
-    } else {
-      query_string[pair[0]].push(decodeURIComponent(pair[1]));
+/* eslint-env browser, jquery */
+
+var QueryString = (
+  function () {
+    var query_string = {}
+    var query = window.location.search.substring(1)
+    var vars = query.split('&')
+    for (var i = 0; i < vars.length; i++) {
+      var pair = vars[i].split('=')
+      if (typeof query_string[pair[0]] === 'undefined') {
+        query_string[pair[0]] = decodeURIComponent(pair[1])
+      } else if (typeof query_string[pair[0]] === 'string') {
+        var arr = [ query_string[pair[0]], decodeURIComponent(pair[1]) ]
+        query_string[pair[0]] = arr
+      } else {
+        query_string[pair[0]].push(decodeURIComponent(pair[1]))
+      }
     }
-  }
-  return query_string;
-}();
+    return query_string
+  }()
+)
 
-window.locale = { _current: 'en' };
+var locale = { _current: 'en' }
+window.locale = locale
 
-window.QueryString = QueryString;
+window.QueryString = QueryString
 
-locale.current = function(_) {
-    if (!arguments.length) return locale._current;
-    if (locale[_] !== undefined) locale._current = _;
-    else if (locale[_.split('-')[0]]) locale._current = _.split('-')[0];
-    else if (locale[_.split('_')[0]]) locale._current = _.split('_')[0];
-    return locale;
-};
+locale.current = function (_) {
+  if (!arguments.length) return locale._current
+  if (locale[_] !== undefined) locale._current = _
+  else if (locale[_.split('-')[0]]) locale._current = _.split('-')[0]
+  else if (locale[_.split('_')[0]]) locale._current = _.split('_')[0]
+  return locale
+}
 
-locale.init = function() {
-  loc = null;
-  var windowLoc = window.location.pathname;
-  for (prop in locale) {
-    if (typeof(prop) == 'string' && prop.length == 2 && locale.hasOwnProperty(prop)) {
-      var token = '/' + prop;
-      if (windowLoc.startsWith(token + '/') || windowLoc == token) {
-        loc = prop;
-        break;
+locale.init = function () {
+  var loc = null
+  var windowLoc = window.location.pathname
+  for (var prop in locale) {
+    if (typeof prop === 'string' && prop.length === 2 &&
+      locale.hasOwnProperty(prop)) {
+      var token = '/' + prop
+      if (windowLoc.startsWith(token + '/') || windowLoc === token) {
+        loc = prop
+        break
       }
     }
   }
   if (loc == null) {
-    if (QueryString.locale !== undefined)
-      loc = QueryString.locale;
-    else {
-      var language = window.navigator.userLanguage || window.navigator.language;
-      loc = language;
+    if (QueryString.locale !== undefined) {
+      loc = QueryString.locale
+    } else {
+      var language = window.navigator.userLanguage || window.navigator.language
+      loc = language
     }
   }
-  if (loc == null || loc == '')
-    loc = 'en';
-  return locale.current(loc);
+  if (loc == null || loc === '') {
+    loc = 'en'
+  }
+  return locale.current(loc)
 }
 
-window.t_exists = function(s, loc) {
-  loc = loc || locale._current;
-  if (!s) return false;
+window.t_exists = function (s, loc) {
+  loc = loc || locale._current
+  if (!s) return false
 
-  var path = s.split(".").reverse(), rep = locale[loc];
+  var path = s.split('.').reverse()
+  var rep = locale[loc]
 
-  while (rep !== undefined && path.length) rep = rep[path.pop()];
+  while (rep !== undefined && path.length) rep = rep[path.pop()]
 
-  return rep !== undefined;
+  return rep !== undefined
 }
+/* TODO: for backwards compatibility, we still define these functions
+   in the window namespace ("window.foo = () => {}") -- but also expose them
+   as exports so code going forward can use these features as a module.
+   Eventually, take away the global usages. */
+if (typeof exports !== 'undefined') { exports.t_exists = window.t_exists }
 
-window.t = function(s, o, loc) {
-    loc = loc || locale._current;
-    if (!s) return s;
+window.t = function (s, o, loc) {
+  loc = loc || locale._current
+  if (!s) return s
 
-    var path = s.split(".").reverse(),
-        rep = locale[loc];
+  var path = s.split('.').reverse()
+  var rep = locale[loc]
 
-    while (rep !== undefined && path.length) rep = rep[path.pop()];
+  while (rep !== undefined && path.length) rep = rep[path.pop()]
 
-    if (rep !== undefined) {
-        if (o) for (var k in o) rep = rep.replace('{' + k + '}', o[k]);
-        return rep;
-    } else {
-        function missing() {
-            var missing = s.replace(/_/g, " ");
-            //if (typeof console !== "undefined") console.error(missing);
-            return missing;
-        }
-
-        if (loc !== 'en') {
-            missing();
-            return t(s, o, 'en');
-        }
-
-        if (o && 'default' in o) {
-            return o['default'];
-        }
-
-        if (/\s/.exec(s) || !/\./.exec(s)) {
-            return s
-        }
-
-        return toTitleCase(s.split(".").pop());
+  if (rep !== undefined) {
+    if (o) for (var k in o) rep = rep.replace('{' + k + '}', o[k])
+    return rep
+  } else {
+    var missing = () => {
+      var m = s.replace(/_/g, ' ')
+      return m
     }
 
-    function toTitleCase(s) {
-        s = s || "";
-        return s.replace(/_/g, " ").replace(/(^[a-z])|(\s[a-z])/g, function(s) { return s.toUpperCase(); });
+    if (loc !== 'en') {
+      missing()
+      return window.t(s, o, 'en')
     }
+
+    if (o && 'default' in o) {
+      return o['default']
+    }
+
+    if (/\s/.exec(s) || !/\./.exec(s)) {
+      return s
+    }
+
+    return toTitleCase(s.split('.').pop())
+  }
+
+  function toTitleCase (s) {
+    s = s || ''
+    return s.replace(/_/g, ' ').replace(/(^[a-z])|(\s[a-z])/g,
+      function (s) {
+        return s.toUpperCase()
+      })
+  }
 }
+if (typeof exports !== 'undefined') { exports.t = window.t }

--- a/index.html
+++ b/index.html
@@ -137,7 +137,15 @@
                 </tr>
               </table>
             </div>
-            <div class="btn btn-small btn-primary" style="margin-top: 10px" onclick="javascript:saveTemplate()"><span style='margin-right:5px' data-translate="button.save_template_settings">Save Template Settings</span><i class="fa fa-save" aria-hidden="true"></i></div>
+            <div id="cmsSaveTemplateButton"
+              class="btn btn-small btn-primary"
+              style="margin-top: 10px">
+              <span style='margin-right:5px'
+                data-translate="button.save_template_settings">
+                  Save Template Settings
+              </span>
+              <i class="fa fa-save" aria-hidden="true"></i>
+            </div>
           </div>
         </div>
         <div role="tabpanel" class="tab-pane" id="imports-exports">

--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
       window.$ = window.jQuery = require('./bootstrap/js/jquery-2.2.4.min.js');
     </script>
     <script type="text/javascript" src="bootstrap/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="application/locale.js"></script>
-    <script type="text/javascript" src="application/loading.js"></script>
     <script type="text/javascript" src="application/actions.js"></script>
     <script type="text/javascript" src="application/dotranslate.js"></script>
   </head>


### PR DESCRIPTION
This includes changes to loading and locale to _allow_ them to be
required as a module, although they also continue to be present
in the global scope for compatibility with old code.

cms.js uses the UJS style where the code itself handles the
binding back to the UI, as opposed to the UI being able to invoke
the code.
