### PR TITLE
Support Community Lands API v2, content upload

### DIFF
--- a/application/actions.js
+++ b/application/actions.js
@@ -186,9 +186,16 @@ ipc.on('has_community_lands_status', function (evt, result) {
   document.getElementById('connection_status').innerHTML = t('text.online')
   if (result !== null && result !== '') {
     var json = JSON.parse(result)
-    if (json.date) {
+    if (json.submissions && json.website) {
+      var date = json.submissions > json.website ? json.submissions : json.website
       document.getElementById('community_lands_sync_date').innerHTML =
-        new Date(json.date)
+        new Date(date)
+    } else if (json.submissions) {
+      document.getElementById('community_lands_sync_date').innerHTML =
+        new Date(json.submissions)
+    } else if (json.website) {
+      document.getElementById('community_lands_sync_date').innerHTML =
+        new Date(json.website)
     } else {
       document.getElementById('community_lands_sync_date').innerHTML =
         t('text.unavailable')
@@ -214,7 +221,7 @@ ipc.on('has_community_lands_backup', function (evt, result) {
     html += ' '
     html += t('text.files_uploaded')
     html += ' '
-    html += json.entity.files_uploaded
+    html += json.entity.submissions_uploaded + json.entity.website_uploaded
   }
   loading.showStatus(html, {
     type: json.error ? 'error' : 'success', timeout: 10000
@@ -415,7 +422,7 @@ updateOnlineStatus()
 function communityLandsUpload () {
   if (navigator.onLine) {
     loading.showLoadingScreen(t('progress.uploading'))
-    ipc.send('community_lands_backup')
+    ipc.send('community_lands_backup', { submissions: true, website: true })
   } else {
     alert(t('alert.no_internet'))
   }

--- a/helpers/settings.js
+++ b/helpers/settings.js
@@ -162,6 +162,10 @@ function getUserFormsDirectory() {
   return path.join(getRootPath(), getStation(), 'Forms');
 }
 
+function getWebsiteContentDirectory() {
+  return path.join(getRootPath(), getStation(), 'content')
+}
+
 function getSharedSecret() {
   return process.env.shared_secret;
 }
@@ -203,6 +207,7 @@ module.exports = {
   getGlobalFormsDirectory: getGlobalFormsDirectory,
   getTracksDirectory: getTracksDirectory,
   getUserFormsDirectory: getUserFormsDirectory,
+  getWebsiteContentDirectory: getWebsiteContentDirectory,
   getSharedSecret: getSharedSecret,
   getSharedUsername: getSharedUsername,
   getRootPath: getRootPath,

--- a/main.js
+++ b/main.js
@@ -407,7 +407,7 @@ ipc.on('community_lands_backup', function(event, arg) {
     var options = {
       hostname: 'localhost',
       port: settings.getPort() || 3000,
-      path: '/backup/latest',
+      path: '/communitylands/latest?submissions=true&website=true',
       method: 'GET'
     }
     http.request(options, function (res) {
@@ -431,7 +431,7 @@ ipc.on('community_lands_status', function (event, arg) {
     var options = {
       hostname: 'localhost',
       port: settings.getPort() || 3000,
-      path: '/backup/status',
+      path: '/communitylands/status',
       method: 'GET'
     }
     http.request(options, function (res) {

--- a/server.js
+++ b/server.js
@@ -110,9 +110,13 @@ app.get('/formList', forms.index)
 app.get('/forms', forms.index)
 app.get('/forms/:id', forms.show)
 
-app.get('/backup/latest', CommunityLands.backup)
-app.get('/backup/all', CommunityLands.resync)
-app.get('/backup/status', CommunityLands.lastBackup)
+app.get('/backup/latest', CommunityLands.Submissions.backup)
+app.get('/backup/all', CommunityLands.Submissions.resync)
+app.get('/backup/status', CommunityLands.Submissions.lastBackup)
+
+app.get('/communitylands/latest', CommunityLands.Content.backup)
+app.get('/communitylands/all', CommunityLands.Content.resync)
+app.get('/communitylands/status', CommunityLands.Content.lastBackup)
 
 app.get('/save/all', Backup.backup)
 app.get('/save/status', Backup.lastBackup)


### PR DESCRIPTION
Change community lands controller to use v2 of the API,
which support multi-type content upload, and use that
to send both submissions and website content all together.

Also, added the path of the content directory to settings.

Finally, updated interface to make use of CL API v2.
