### PR TITLE
Ensure a baseUrl hostname is provided when offline

### DIFF
--- a/helpers/autoconfig.js
+++ b/helpers/autoconfig.js
@@ -45,4 +45,6 @@ Object.keys(ifaces).forEach(function (ifname) {
   })
 })
 
+process.env.baseUrl = process.env.baseUrl || ('http://localhost:' + process.env.port)
+
 console.log('')


### PR DESCRIPTION
When offline, explicitly set the hostname to localhost; otherwise,
the baseUrl becomes undefined and links do not work.

See #5