### PR TITLE
Correct ZIP step of build-full

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -5,8 +5,6 @@ utils.Builder.configure({
   APP_DISPLAY_NAME: 'Community Lands Monitoring Station'
 })
 
-console.log(process.argv);
-
 if (process.argv.length >= 3)
   if (process.argv[2] == 'all') {
     utils.Builder.dist('mac');

--- a/build-full.sh
+++ b/build-full.sh
@@ -159,7 +159,6 @@ then
   then
     # cd installer-win-x64
     zip -q -r MonitoringStation-win-$d.zip installer-win-x64/*.exe
-    cd ..
   fi
 
   if [ $mac == 0 ]


### PR DESCRIPTION
Was `cd`-ing to the wrong directory for windows builds.

Also removed unnecessary logging.