### PR TITLE
Update npm scripts, authorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ $ electron .
 Developing on a Mac workstation, the project can be built to an
 installable Windows or Mac version via electron-packager; do this
 with `build-full.sh`. You must have electron installed at the system level,
-and all the community-lands repositories checked out as siblings of your community-lands-monitoring-station. `wine` is required to build for Windows.
+and all the community-lands repositories checked out as siblings of your community-lands-monitoring-station. `wine` and `mono` are required to build for Windows.
 The build script will `git pull`, `npm install` and synchronize dependencies
 to make a consistent build. The final step will upload the build to the
 Community Lands download page; for this to work, you must have your public key
 installed on that system.
 
 `build-full.sh` supports running a single or a range of steps; see the
-code for options.
+code for options. There are also frequently-used configurations for
+`build-full.sh` that can be used with `npm run` declared in `package.json`.

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "passport"
   ],
   "scripts": {
-    "build:old": "sh build-full.sh --no-upload",
-    "build": "sh build-full.sh --mac --no-upload --custom",
+    "build": "sh build-full.sh",
     "build:mac": "sh build-full.sh --mac",
     "build:win": "sh build-full.sh --win",
     "build:local": "sh build-full.sh --no-upload --custom --mac",
@@ -23,6 +22,7 @@
     "postinstall": "npmpd"
   },
   "author": "Solertium",
+  "authors": "Community Lands",
   "license": "Unlicense",
   "homepage": "https://github.com/community-lands/community-lands-monitoring-station",
   "repository": {


### PR DESCRIPTION
Changed `npm run build` to run the default build-full target,
and updated the authors to Community Lands.