### PR TITLE
Support additional tiles directories

### DIFF
--- a/application/client-modules/tiles.js
+++ b/application/client-modules/tiles.js
@@ -39,7 +39,35 @@
         }
         content += '</div>'
       }
+
       document.getElementById('tiles_listing').innerHTML = content
+      var tilesDirectoriesHTML = '<table class="table table-condensed small">';
+      for (i in result.directories) {
+        var dir = result.directories[i]
+        tilesDirectoriesHTML += '<tr>'
+        tilesDirectoriesHTML += '<td>'
+        tilesDirectoriesHTML += '<div class="btn btn-xs"><i class="' + (dir.available ? 'fa fa-check text-success' : 'fa fa-question text-warning') + '"></div>'
+        tilesDirectoriesHTML += '</td>'
+        tilesDirectoriesHTML += '<td>' + dir.directory + '</td>'
+        tilesDirectoriesHTML += '<td align="right">'
+        if (!dir.isDefault) {
+          tilesDirectoriesHTML += '<div class="btn btn-xs tilesDirectoryRemoveBtn" data-directory="' + dir.directory + '">'
+          tilesDirectoriesHTML += '<i class="fa fa-remove"></i>'
+          tilesDirectoriesHTML += '</div>'
+        }
+        tilesDirectoriesHTML += '</td>'
+        tilesDirectoriesHTML += '</tr>'
+      }
+      tilesDirectoriesHTML += '</table>';
+      document.getElementById('tiles_folder').innerHTML = tilesDirectoriesHTML;
+
+      var els = document.getElementsByClassName('tilesDirectoryRemoveBtn');
+      for (var i in els) {
+        els[i].onclick = function() {
+          if (confirm(t('confirm.removeTilesDirectory')))
+            ipc.send('tiles_remove_directory', { directory: this.getAttribute('data-directory') });
+        }
+      }
     }
   })
 
@@ -49,5 +77,11 @@
   });
 
   ipc.send('tiles_list')
+
+  $(document).ready(function() {
+    $("#tilesDirectoryChooserBtn").click(function() {
+      ipc.send('tiles_add_directory');
+    });
+  });
 
 })(window.app)

--- a/controllers/tile-layers.js
+++ b/controllers/tile-layers.js
@@ -1,11 +1,18 @@
 var settings = require('../helpers/settings')
 var tiles = require('../helpers/tile-layers')
+var ServerEvents = require('../helpers/server-events')
 
 var fs = require('fs'),
   path = require('path')
 
+var CACHED_JSON = null;
+
+ServerEvents.on('tl_after_reinspect', function(json) {
+  CACHED_JSON = json;
+});
+
 function listTileLayers (req, res, next) {
-  tiles.get(function(err, md) {
+  getTilesInfo(function(err, md) {
     if (err) {
       res.json(500, {
         message: err.message,
@@ -13,12 +20,16 @@ function listTileLayers (req, res, next) {
       })
     } else {
       var names = []
-      Object.keys(md).forEach(function(file) {
-        var stats = md[file]
+      Object.keys(md).forEach(function(id) {
+        var stats = md[id]
         if (stats.valid) {
-          var uri = '/monitoring-files/Maps/Tiles/' + file
-          names.push({name: file, uri: uri, format: stats.format});
-        }
+          var uri;
+          if (stats.directory == settings.getDefaultTilesDirectory())
+            uri = '/monitoring-files/Maps/Tiles/' + stats.name;
+          else
+            uri = '/map-tiles/' + id
+          names.push({name: stats.name, key: stats.key, uri: uri, format: stats.format});
+        };
       });
       names.sort(function(a, b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0 });
       res.json(names)
@@ -26,6 +37,43 @@ function listTileLayers (req, res, next) {
   })
 }
 
+function getTile (req, res, next) {
+  getTilesInfo(function(err, md) {
+    if (err)
+      res.send(500)
+    else {
+      var id = req.params['id'], file = req.params['0']
+      if (!file)
+        res.send(404)
+      else if (md[id]) {
+        var stats = md[id]
+        var filePath = path.join(stats.directory, stats.name, file)
+        var contentType = 'image/' + (stats.format == 'png' ? 'png' : 'jpeg');
+
+        res.type(contentType).sendFile(filePath);
+      }
+      else
+        res.send(404)
+    }
+  });
+}
+
+/**
+ * Performance boost
+ */
+function getTilesInfo(cb) {
+  if (CACHED_JSON)
+    cb(null, CACHED_JSON)
+  else {
+    tiles.get(function(err, data) {
+      if (!err)
+        CACHED_JSON = data;
+      cb(err, data);
+    });
+  }
+}
+
 module.exports = {
-  listTileLayers: listTileLayers
+  listTileLayers: listTileLayers,
+  getTile: getTile
 }

--- a/helpers/settings.js
+++ b/helpers/settings.js
@@ -51,6 +51,19 @@ function get(cb) {
   });
 }
 
+function patch(settings, cb) {
+  get(function(err, selected) {
+    if (err)
+      cb(err)
+    else {
+      Object.keys(settings).forEach(function(key) {
+        selected[key] = settings[key]
+        save(selected, cb);
+      });
+    }
+  });
+}
+
 function save(settings, cb) {
   if (LOCATION) {
     var properties = ''
@@ -146,7 +159,15 @@ function mapFilter() {
   };
 }
 
-function getTilesDirectory() {
+function getTilesDirectories() {
+  var dirs = [ getDefaultTilesDirectory() ];
+  var addl = process.env.tiles_directories;
+  if (addl)
+    dirs = dirs.concat(addl.split(";"))
+  return dirs;
+}
+
+function getDefaultTilesDirectory() {
   return path.join(getRootPath(), 'Maps', 'Tiles');
 }
 
@@ -203,6 +224,7 @@ module.exports = {
   load: load,
   get: get,
   save: save,
+  patch: patch,
   getDefaults: getDefaultSettings,
   getDataDirectory: getDataDirectory,
   getBackupDirectory: getBackupDirectory,
@@ -214,7 +236,8 @@ module.exports = {
   getCommunityLandsPort: getCommunityLandsPort,
   getFiltersDirectory: getFiltersDirectory,
   getMapFilterSettings: mapFilter,
-  getTilesDirectory: getTilesDirectory,
+  getTilesDirectories: getTilesDirectories,
+  getDefaultTilesDirectory: getDefaultTilesDirectory,
   getGlobalMapsDirectory: getGlobalMapsDirectory,
   getGlobalFormsDirectory: getGlobalFormsDirectory,
   getTracksDirectory: getTracksDirectory,

--- a/index.html
+++ b/index.html
@@ -98,10 +98,21 @@
           </div>
           <h4><i class="fa fa-map fa-lg" aria-hidden="true"></i> &#160; <span data-translate="title.saved_tiles"></span></h4>
           <div class="well">
-            <div data-translate="prompt.tiles_folder">
-              Folder for custom Map Tiles:
+            <div>
+              <div class="pull-right">
+                <button id="tilesDirectoryChooserBtn" class="btn btn-xs btn-primary">
+                  <span style='margin-right:5px' data-translate="button.add_tiles_directory">Add Another Tiles Directory</span>
+                  <i class="fa fa-plus"></i>
+                </button>
+              </div>
+              <div>
+                <div data-translate="prompt.tiles_folder">
+                  Folder for custom Map Tiles:
+                </div>
+              </div>
+              <div style="clear:both;height:1px">&nbsp;</div>
+              <div><b id="tiles_folder"></b></div>
             </div>
-            <div><b id="tiles_folder"></b></div>
             <div data-translate="help.tiles.usage" class="help-block"></div>
             <div id="tiles_listing" style="margin-top:20px">
               <div class="text-center">

--- a/main.js
+++ b/main.js
@@ -37,10 +37,14 @@ var glob = require('glob')
 var readline = require('readline')
 var path = require('path')
 var unzip = require('unzip2');
+var watcher = require('chokidar');
 var GeoJson = require('./helpers/rebuild-geojson')
 var async = require('async');
 var i18n = require('./helpers/locale.js');
 var Tiles = require('./helpers/tile-layers.js');
+
+var TilesWatcherTimeout = null;
+var TilesWatcher = null;
 
 ipc.on('show_configuration', function (event, arg) {
   try {
@@ -52,7 +56,7 @@ ipc.on('show_configuration', function (event, arg) {
       'shared_secret': settings.getSharedSecret(),
       'locale': settings.getLocale() || _defaults.locale,
       'community_lands': !(settings.getCommunityLandsServer() === undefined || settings.getCommunityLandsToken() === undefined),
-      'tiles': settings.getTilesDirectory(),
+      'tiles': settings.getDefaultTilesDirectory(),
       'tracks': settings.getTracksDirectory()
     }
     console.log(_results)
@@ -203,23 +207,40 @@ ipc.on('form_list', function (event, arg) {
 
 function listTiles(cb) {
   Tiles.get(function(err, md) {
-    if (err)
+    if (err) {
+      /*
+       * Probably in cases of major error, should reset any custom installed 
+       * tile directories and start fresh
+       */
       cb(err)
-    else {
+    } else {
       var warnFiles = warnFolders = false;
-      var result = { error: false, tiles: [], warnings: [] };
+      var result = { error: false, tiles: [], warnings: [], directories: [] };
       Object.keys(md).forEach(function(file) {
         var stats = md[file];
         if (!stats.eligible)
           warnFiles = true;
         else {
-          stats.name = file;
           result.tiles.push(stats);
         }
       });
       if (warnFiles)
         result.warnings.push("error.files_in_tiles_folder")
       result.tiles.sort(function(a, b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0 });
+      result.directories = settings.getTilesDirectories().map(function(value) {
+        var available = false;
+        try {
+          fs.accessSync(value, fs.F_OK | fs.R_OK); //only need to read
+          available = true;
+        } catch (e) { //Directory unavailable
+        }
+        return {
+          available: available,
+          directory: value,
+          isDefault: value == settings.getDefaultTilesDirectory()
+        }
+      });
+
       cb(null, result);
     }
   });
@@ -296,6 +317,58 @@ function unzipTrackData(source, target) {
   }
 }
 
+ipc.on('tiles_add_directory', function (event) {
+  var options = {
+    properties: ['openDirectory'],
+    defaultPath: settings.getDataDirectory()
+  }
+  dialog.showOpenDialog(mainWindow, options, function (folders) {
+    if (folders) {
+      var folder = folders[0];
+      var existing = settings.getTilesDirectories();
+      if (existing.indexOf(folder) >= 0)
+        event.sender.send('show_status', { message: 'errors.duplicate_tiles_folder', options: { type: 'error' } });
+      else {
+        var current = process.env.tiles_directories;
+        if (!current)
+          current = folder;
+        else
+          current += ';' + folder;
+        settings.patch({ tiles_directories: current }, function (err) {
+          if (!err) {
+            process.env.tiles_directories = current;
+            setupTilesWatcher();
+            refreshTiles();
+          }
+        });
+      }
+    }
+  });
+});
+
+ipc.on('tiles_remove_directory', function (event, args) {
+  var current = (process.env.tiles_directories || '').split(";")
+  var idx = current.indexOf(args.directory)
+  if (idx > -1)
+    delete current[idx]
+  var result = ''
+  for (var i = 0; i < current.length; i++) {
+    if (current[i]) {
+      if (!result)
+        result = current[i]
+      else
+        result += ';' + current[i]
+    }
+  }
+  settings.patch({ tiles_directories: result }, function (err) {
+    if (!err) {
+      process.env.tiles_directories = result;
+      setupTilesWatcher();
+      refreshTiles();
+    }
+  });
+});
+
 ipc.on('tracks_list', function (event, arg) {
   var pattern = path.join(settings.getTracksDirectory(), "**", "*.+(gpx|csv)");
   glob(pattern, { matchBase: true, nodir: true, nocase: true }, function(err, matches) {
@@ -368,7 +441,7 @@ ipc.on('settings_list', function (event, arg) {
 })
 
 ipc.on('settings_save', function (event, arg) {
-  settings.save(arg, function (err) {
+  settings.patch(arg, function (err) {
     if (err) {
       event.sender.send('has_settings_save', '{"error",true, "code":"could_not_save_settings", "message":"Could not save settings file"}')
     } else {
@@ -448,8 +521,8 @@ ipc.on('list_map_layers', function (event, arg) {
     else {
       event.sender.send('has_list_map_layers', result.tiles.filter(function(value) {
         return value.valid;
-      }).map(function(value) { 
-        return {name: value.name, value: value.name}
+      }).map(function(value) {
+        return {name: value.name, value: value.key + ''}
       }));
     }
   });
@@ -482,7 +555,6 @@ ipc.on('import_files', function(event, args) {
               });
             });
           } catch (e) {
-            console.log(e);
             event.sender.send('has_import_files', { error: true, code: 'import_unzip_failed', ex: e });
           }
         }
@@ -562,17 +634,38 @@ try {
 } catch (e) { // It's ok
 }
 
-var TilesDir = settings.getTilesDirectory()
-try {
-  fs.ensureDirSync(TilesDir)
-} catch (e) { // It's ok
-}
-try {
-  fs.watch(TilesDir, function (evt, filename) {
-    refreshTiles();
+function setupTilesWatcher() {
+  if (TilesWatcher)
+    TilesWatcher.close();
+
+  TilesWatcher = new watcher.FSWatcher({
+    //ignored: /(^|[\/\\])\../,
+    ignoreInitial: true,
+    persistent: true,
+    depth: 1
   });
-} catch (e) { // It's ok
+
+  var TilesDirs = settings.getTilesDirectories();
+  for (var i in TilesDirs) {
+    var TilesDir = TilesDirs[i];
+    if (TilesDir == settings.getDefaultTilesDirectory()) {
+      try {
+        fs.ensureDirSync(TilesDir)
+      } catch (e) { // It's ok
+      }
+    }
+    try {
+      TilesWatcher.add(TilesDir)
+    } catch (e) { // It's ok
+    }
+  }
+  TilesWatcher.on('raw', function(evt, path) {
+    if (TilesWatcherTimeout)
+      clearTimeout(TilesWatcherTimeout)
+    TilesWatcherTimeout = setTimeout(refreshTiles, 1000);
+  });
 }
+setupTilesWatcher();
 
 function refreshTiles() {
   Tiles.refresh(function() {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "archiver": "*",
     "async": "~0.2.5",
     "body-parser": "^1.13.3",
+    "chokidar": "^1.6.1",
     "community-lands-software-utils": "git+ssh://github.com/community-lands/community-lands-software-utils.git#master",
     "csv-parse": "^1.0.4",
     "dotenv": "^2.0.0",

--- a/server.js
+++ b/server.js
@@ -64,9 +64,10 @@ app.get('/mapfilter/filters', MapFilter.listFilters)
 app.post('/mapfilter/filters/local', bodyParser.json(), MapFilter.saveFilter)
 app.delete('/mapfilter/filters/local/:id', MapFilter.deleteFilter);
 
+// Map Tiles
 app.get('/bing-metadata/:url', Bing.metadata)
-
 app.get('/bing-proxy/:url', Bing.prepare, Bing.proxy)
+app.get('/map-tiles/:id*', TileLayers.getTile)
 
 app.get('/tracks', Tracks.tracks)
 app.get('/sounds/:file', Tracks.sounds)


### PR DESCRIPTION
Users can explicitly watch selected directories containing
their tiles. The rules for these folders are the same as the
default tiles folder.

All users will have the default tiles folder at their disposal
and can still place files there; this folder can not be removed.

See #30